### PR TITLE
feat: add workflow for publishing libraries after merge

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{py}]
+indent_style = space
+indent_size = 4
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -1,0 +1,38 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
+  release-to-charmhub:
+    name: Release latest version of libraries to Charmhub
+    runs-on: ubuntu-latest
+    needs:
+      - ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release updated libraries to Charmhub
+        uses: canonical/charming-actions/release-libraries@2.4.0
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}" # FIXME: Expires 2024-10-30
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Title gives it away, but this pull request sets up the `release-libs` workflow for `hpc-libs`. Pretty much the same thing as the the workflow from `storage-libs`.

I added a token to the repository secrets that will allow us to upload the `slurm_ops` library. It will expire while we are in The Hague for the Engineering Sprint in October. I'm very tempted to write us a tool like [`tokenator`](https://github.com/snapcrafters/tokenator) that enables us to bulk refresh our repo secrets so it's not this weird song and dance when we try to publish new updates to Charmhub :sweat_smile: 

### Misc.

I added a _.editorconfig_ file. Helps with consistency across IDE's. We can extend rules farther as we need to :smiley: 