### PR TITLE
fix(ci): bump release-libraries to 2.6.1

### DIFF
--- a/.github/workflows/release-libs.yaml
+++ b/.github/workflows/release-libs.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Release updated libraries to Charmhub
-        uses: canonical/charming-actions/release-libraries@2.4.0
+        uses: canonical/charming-actions/release-libraries@2.6.1
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}" # FIXME: Expires 2024-10-30
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
For some reason is looking for metadata.yaml file.