### PR TITLE
feat: add `set_configs` operation to `SlurmManager`

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -57,6 +57,7 @@ import logging
 import os
 import subprocess
 import tempfile
+from collections.abc import Mapping
 
 import yaml
 
@@ -164,6 +165,18 @@ class SlurmManager:
         the specific managed service. (the slurmctld service uses the slurm parent key)
         """
         _set_config(f"{self._service.config_name}.{key}={value}")
+
+    def set_configs(self, configs: Mapping[str, str]):
+        """Set many snap configurations for the managed slurm service.
+
+        See the configuration section from the [Slurm readme](https://github.com/charmed-hpc/slurm-snap#configuration)
+        for a list of all the available configurations.
+
+        Note that this will only allow configuring the settings that are exclusive to
+        the specific managed service. (the slurmctld service uses the slurm parent key)
+        """
+        configs = [f"{self._service.config_name}.{key}={value}" for key, value in configs.items()]
+        _set_config(*configs)
 
     def get_config(self, key: str) -> str:
         """Get a snap config for the managed slurm service.

--- a/tests/integration/slurm_ops/test_manager.py
+++ b/tests/integration/slurm_ops/test_manager.py
@@ -42,10 +42,11 @@ def test_rotate_key(slurm_manager: SlurmManager) -> None:
 def test_slurm_config(slurm_manager: SlurmManager) -> None:
     """Test that the slurm config can be changed."""
     slurm_manager.set_config("cluster-name", "test-cluster")
+    slurm_manager.set_configs({"max-tasks-per-node": "30000", "inactive-limit": "60000"})
 
-    value = slurm_manager.get_config("cluster-name")
-
-    assert value == "test-cluster"
+    assert slurm_manager.get_config("cluster-name") == "test-cluster"
+    assert slurm_manager.get_config("max-tasks-per-node") == "30000"
+    assert slurm_manager.get_config("inactive-limit") == "60000"
 
     with open("/var/snap/slurm/common/etc/slurm/slurm.conf", "r") as f:
         output = f.read()
@@ -57,6 +58,10 @@ def test_slurm_config(slurm_manager: SlurmManager) -> None:
         key, value = entry
         if key == "ClusterName":
             assert value == "test-cluster"
+        elif key == "MaxTasksPerNode":
+            assert value == "30000"
+        elif key == "InactiveLimit":
+            assert value == "60000"
 
 
 @pytest.mark.order(4)

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -91,6 +91,28 @@ class SlurmOpsBase:
         args = subcmd.call_args[0][0]
         self.assertEqual(args, ["snap", "set", "slurm", f"{self.config_name}.key=value"])
 
+    def test_set_configs(self, subcmd, *_) -> None:
+        """Test that the manager calls the correct set_config command with multiple configs."""
+        self.manager.set_configs(
+            {
+                "key1": "value1",
+                "key2": "value2",
+                "key3": "value3",
+            }
+        )
+        args = subcmd.call_args[0][0]
+        self.assertEqual(
+            args,
+            [
+                "snap",
+                "set",
+                "slurm",
+                f"{self.config_name}.key1=value1",
+                f"{self.config_name}.key2=value2",
+                f"{self.config_name}.key3=value3",
+            ],
+        )
+
     def test_get_config(self, subcmd, *_) -> None:
         """Test that the manager calls the correct get_config command."""
         subcmd.return_value = b"value"


### PR DESCRIPTION
Implements a simple utility method to be able to set configs in bulk. This is required by the Slurm charms since they generate and set configs in bulk.