### PR TITLE
feat(ci): pull gambol from snap store

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,9 +58,6 @@ jobs:
           channel: 5.21/stable
       - name: Set up gambol
         run: |
-          wget https://github.com/NucciTheBoss/gambol/releases/download/v0.1.0-rc2/gambol_0.1.0_amd64-rc2.snap
-          sudo snap install ./gambol_*.snap --dangerous
-          sudo snap connect gambol:lxd lxd:lxd
-          sudo snap connect gambol:dot-gambol
+          sudo snap install gambol
       - name: Run tests
         run: tox -e integration


### PR DESCRIPTION
Pull gambol from the Snap Store rather than a pre-release build from GitHub Releases: https://snapcraft.io/gambol

Simplifies things for us as the connections to `dot-gambol` and `lxd` [now occur automatically](https://forum.snapcraft.io/t/automatic-connection-requests-for-gambol/40787?u=nuccitheboss) so we don't have to worry about forgetting to accidentally connect the right interfaces.