### PR TITLE
feat!: use composition and inheritance to build service managers

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -42,7 +42,6 @@ class ApplicationCharm(CharmBase):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        # Charm events defined in the NFSRequires class.
         self._slurm_manager = SlurmctldManager()
         self.framework.observe(
             self.on.install,

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -57,6 +57,7 @@ class ApplicationCharm(CharmBase):
 """
 
 __all__ = [
+    "format_key",
     "install",
     "version",
     "ServiceType",
@@ -65,6 +66,7 @@ __all__ = [
 
 import json
 import logging
+import re
 import subprocess
 from collections.abc import Mapping
 from enum import Enum
@@ -86,6 +88,29 @@ LIBPATCH = 1
 PYDEPS = ["pyyaml>=6.0.1"]
 
 _logger = logging.getLogger(__name__)
+_acronym = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_kebabize = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+def format_key(key: str) -> str:
+    """Format Slurm configuration keys from SlurmCASe into kebab case.
+
+    Args:
+        key: Slurm configuration key to convert to kebab case.
+
+    Notes:
+       Slurm configuration syntax does not follow proper PascalCasing
+       format, so we cannot put keys directly through a kebab case converter
+       to get the desired format. Some additional processing is needed for
+       certain keys before the key can properly kebabized.
+
+       For example, without additional preprocessing, the key `CPUs` will
+       become `cp-us` if put through a kebabizer with being preformatted to `Cpus`.
+    """
+    if "CPUs" in key:
+        key = key.replace("CPUs", "Cpus")
+    key = _acronym.sub(r"-", key)
+    return _kebabize.sub(r"-", key).lower()
 
 
 def install() -> None:

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -81,7 +81,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = ["pyyaml>=6.0.1"]

--- a/tests/integration/slurm_ops/test_manager.py
+++ b/tests/integration/slurm_ops/test_manager.py
@@ -7,15 +7,16 @@ import base64
 import pytest
 
 import lib.charms.hpc_libs.v0.slurm_ops as slurm
+from lib.charms.hpc_libs.v0.slurm_ops import ServiceType, SlurmManagerBase
 
 
 @pytest.fixture
-def slurmctld() -> slurm.SlurmctldManager:
-    return slurm.SlurmctldManager()
+def slurmctld() -> SlurmManagerBase:
+    return SlurmManagerBase(ServiceType.SLURMCTLD)
 
 
 @pytest.mark.order(1)
-def test_install(slurmctld: slurm.SlurmctldManager) -> None:
+def test_install(slurmctld: SlurmManagerBase) -> None:
     """Install Slurm using the manager."""
     slurm.install()
     slurmctld.enable()
@@ -28,7 +29,7 @@ def test_install(slurmctld: slurm.SlurmctldManager) -> None:
 
 
 @pytest.mark.order(2)
-def test_rotate_key(slurmctld: slurm.SlurmctldManager) -> None:
+def test_rotate_key(slurmctld: SlurmManagerBase) -> None:
     """Test that the munge key can be rotated."""
     old_key = slurmctld.munge.get_key()
     slurmctld.munge.generate_key()
@@ -37,7 +38,7 @@ def test_rotate_key(slurmctld: slurm.SlurmctldManager) -> None:
 
 
 @pytest.mark.order(3)
-def test_slurm_config(slurmctld: slurm.SlurmctldManager) -> None:
+def test_slurm_config(slurmctld: SlurmManagerBase) -> None:
     """Test that the slurm config can be changed."""
     slurmctld.config.set({"cluster-name": "test-cluster"})
     value = slurmctld.config.get("cluster-name")

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -9,6 +9,7 @@ import subprocess
 from unittest.mock import patch
 
 import charms.hpc_libs.v0.slurm_ops as slurm
+from charms.hpc_libs.v0.slurm_ops import ServiceType, SlurmManagerBase
 from pyfakefs.fake_filesystem_unittest import TestCase
 
 MUNGEKEY = b"1234567890"
@@ -161,10 +162,10 @@ class SlurmOpsBase:
 
 
 parameters = [
-    (slurm.SlurmctldManager(), "slurm"),
-    (slurm.SlurmdManager(), "slurmd"),
-    (slurm.SlurmdbdManager(), "slurmdbd"),
-    (slurm.SlurmrestdManager(), "slurmrestd"),
+    (SlurmManagerBase(ServiceType.SLURMCTLD), "slurm"),
+    (SlurmManagerBase(ServiceType.SLURMD), "slurmd"),
+    (SlurmManagerBase(ServiceType.SLURMDBD), "slurmdbd"),
+    (SlurmManagerBase(ServiceType.SLURMRESTD), "slurmrestd"),
 ]
 
 for manager, config_name in parameters:

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -44,6 +44,11 @@ class TestSlurmOps(TestCase):
     def setUp(self) -> None:
         self.setUpPyfakefs()
 
+    def test_format_key(self, _) -> None:
+        """Test that `kebabize` properly formats slurm keys."""
+        self.assertEqual(slurm.format_key("CPUs"), "cpus")
+        self.assertEqual(slurm.format_key("AccountingStorageHost"), "accounting-storage-host")
+
     def test_install(self, subcmd) -> None:
         """Test that `slurm_ops` calls the correct install command."""
         slurm.install()

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -6,11 +6,11 @@
 
 import base64
 import subprocess
+from unittest import TestCase
 from unittest.mock import patch
 
 import charms.hpc_libs.v0.slurm_ops as slurm
 from charms.hpc_libs.v0.slurm_ops import ServiceType, SlurmManagerBase
-from pyfakefs.fake_filesystem_unittest import TestCase
 
 MUNGEKEY = b"1234567890"
 MUNGEKEY_BASE64 = base64.b64encode(MUNGEKEY)
@@ -40,9 +40,6 @@ installed:          23.11.7             (x1) 114MB classic
 
 @patch("charms.hpc_libs.v0.slurm_ops.subprocess.check_output")
 class TestSlurmOps(TestCase):
-
-    def setUp(self) -> None:
-        self.setUpPyfakefs()
 
     def test_format_key(self, _) -> None:
         """Test that `kebabize` properly formats slurm keys."""
@@ -74,9 +71,6 @@ class TestSlurmOps(TestCase):
 @patch("charms.hpc_libs.v0.slurm_ops.subprocess.check_output")
 class SlurmOpsBase:
     """Test the Slurm service operations managers."""
-
-    def setUp(self) -> None:
-        self.setUpPyfakefs()
 
     def test_config_name(self, *_) -> None:
         """Test that the config name is correctly set."""

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ commands =
 description = Run unit tests
 deps =
     pytest
-    pyfakefs
     coverage[toml]
     -r {tox_root}/requirements.txt
 commands =


### PR DESCRIPTION
This pull request enhances the API of `slurm_ops` to use composition and inheritance to build the Slurm service operations managers. This makes it easier for us to construct managers around `slurmctld`, `slurmd`, `slurmdbd`, and `slurmrestd` and share logic for configuration and service management between them. 

### Some use cases

bulk update the configuration of slurmctld:

```python3
from charms.hpc_libs.v0.slurm_ops import SlurmManagerBase, ServiceType

slurmctld = SlurmManagerBase(ServiceType.SLURMCTLD)
slurmctld.config.set({"option1": "value1", "option2": "value2"})
```

set a new munge key:

```python3
from charms.hpc_libs.v0.slurm_ops import SlurmManagerBase, ServiceType

slurmd = SlurmManagerBase(ServiceType.SLURMD)
slurmd.munge.set_key("encodedmungekey")
slurmd.munge.restart()
```

start slurmrestd:

```python3
from charms.hpc_libs.v0.slurm_ops import SlurmManagerBase, ServiceType

slurmrestd = SlurmManagerBase(ServiceType.SLURMRESTD)
slurmrestd.enable()
```

add additional, charm-specific functionality:

```python3
from charms.hpc_libs.v0.slurm_ops import SlurmManagerBase, ServiceType

class SlurmctldManager(SlurmManagerBase)

    def __init__(self) -> None:
        super().__init__(ServiceType.SLURMCTLD)

        # Compose additional manager functionality.
        self.cgroup = ...
```

### Misc.

Adds kebabizer from @jedel1043. The function `format_key(...)` will be used to format Slurm configuration keys before passing off to the Slurm configuration editor.