### PR TITLE
feat: enable bulk getting and unsetting of configuration options

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -59,6 +59,7 @@ __all__ = [
     "format_key",
     "install",
     "version",
+    "ConfigurationManager",
     "ServiceType",
     "SlurmManagerBase",
 ]

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -202,8 +202,8 @@ class ServiceManager:
 class ConfigurationManager:
     """Control configuration of a Slurm component."""
 
-    def __init__(self, service: ServiceType) -> None:
-        self._service = service
+    def __init__(self, name: str) -> None:
+        self._name = name
 
     def get_options(self, *keys: str) -> Mapping[str, Any]:
         """Get given configurations values for Slurm component."""
@@ -215,20 +215,20 @@ class ConfigurationManager:
 
         return configs
 
-    def get(self, key: str) -> Any:
+    def get(self, key: Optional[str] = None) -> Any:
         """Get specific configuration value for Slurm component."""
-        key = f"{self._service.config_name}.{key}"
+        key = f"{self._name}.{key}" if key else self._name
         config = json.loads(_snap("get", "-d", "slurm", key))
         return config[key]
 
     def set(self, config: Mapping[str, Any]) -> None:
         """Set configuration for Slurm component."""
-        args = [f"{self._service.config_name}.{k}={json.dumps(v)}" for k, v in config.items()]
+        args = [f"{self._name}.{k}={json.dumps(v)}" for k, v in config.items()]
         _snap("set", "slurm", *args)
 
-    def unset(self, *keys) -> None:
+    def unset(self, *keys: str) -> None:
         """Unset configuration for Slurm component."""
-        args = [f"{self._service.config_name}.{k}!" for k in keys]
+        args = [f"{self._name}.{k}" for k in keys] if len(keys) > 0 else [self._name]
         _snap("unset", "slurm", *args)
 
 
@@ -236,8 +236,9 @@ class MungeManager(ServiceManager):
     """Manage `munged` service operations."""
 
     def __init__(self) -> None:
-        self._service = ServiceType.MUNGED
-        self.config = ConfigurationManager(ServiceType.MUNGED)
+        service = ServiceType.MUNGED
+        self._service = service
+        self.config = ConfigurationManager(service.config_name)
 
     def get_key(self) -> str:
         """Get the current munge key.
@@ -265,5 +266,5 @@ class SlurmManagerBase(ServiceManager):
 
     def __init__(self, service: ServiceType) -> None:
         self._service = service
-        self.config = ConfigurationManager(service)
+        self.config = ConfigurationManager(service.config_name)
         self.munge = MungeManager()

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -82,7 +82,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = ["pyyaml>=6.0.1"]

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -79,19 +79,19 @@ class SlurmOpsBase:
     def test_enable(self, subcmd, *_) -> None:
         """Test that the manager calls the correct enable command."""
         self.manager.enable()
-        calls = [args[0][0] for args in subcmd.call_args_list]
 
+        args = subcmd.call_args[0][0]
         self.assertEqual(
-            calls[0], ["snap", "start", "--enable", f"slurm.{self.manager._service.value}"]
+            args, ["snap", "start", "--enable", f"slurm.{self.manager._service.value}"]
         )
 
     def test_disable(self, subcmd, *_) -> None:
         """Test that the manager calls the correct disable command."""
         self.manager.disable()
-        calls = [args[0][0] for args in subcmd.call_args_list]
 
+        args = subcmd.call_args[0][0]
         self.assertEqual(
-            calls[0], ["snap", "stop", "--disable", f"slurm.{self.manager._service.value}"]
+            args, ["snap", "stop", "--disable", f"slurm.{self.manager._service.value}"]
         )
 
     def test_restart(self, subcmd, *_) -> None:
@@ -120,6 +120,14 @@ class SlurmOpsBase:
         self.assertEqual(args, ["snap", "get", "-d", "slurm", f"{self.config_name}.key"])
         self.assertEqual(value, "value")
 
+    def test_get_config_all(self, subcmd) -> None:
+        """Test that manager calls the correct `snap get ...` with no arguments given."""
+        subcmd.return_value = '{"%s": "value"}' % self.config_name
+        value = self.manager.config.get()
+        args = subcmd.call_args[0][0]
+        self.assertEqual(args, ["snap", "get", "-d", "slurm", self.config_name])
+        self.assertEqual(value, "value")
+
     def test_set_config(self, subcmd, *_) -> None:
         """Test that the manager calls the correct `snap set ...` command."""
         self.manager.config.set({"key": "value"})
@@ -130,7 +138,13 @@ class SlurmOpsBase:
         """Test that the manager calls the correct `snap unset ...` command."""
         self.manager.config.unset("key")
         args = subcmd.call_args[0][0]
-        self.assertEqual(args, ["snap", "unset", "slurm", f"{self.config_name}.key!"])
+        self.assertEqual(args, ["snap", "unset", "slurm", f"{self.config_name}.key"])
+
+    def test_unset_config_all(self, subcmd) -> None:
+        """Test the manager calls the correct `snap unset ...` with no arguments given."""
+        self.manager.config.unset()
+        args = subcmd.call_args[0][0]
+        self.assertEqual(args, ["snap", "unset", "slurm", self.config_name])
 
     def test_generate_munge_key(self, subcmd, *_) -> None:
         """Test that the manager calls the correct `mungectl` command."""


### PR DESCRIPTION
This pull request adds the ability to both bulk get and unset configuration options on slurm config objects. This functionality will be helpful for both if we want to reset the state of Slurm, and quickly get configuration information for various Slurm objects for comparison against new information received by the charms.

For example:

```python3
slurmctld = SlurmManagerBase(ServiceType.SLURMCTLD)

# Get the entire Slurm controller configuration
slurmctld.config.get()

# Reset the configuration
slurmctld.config.unset()
```

### Misc.

* Fixes a bug with `.unset(...)`. If we use `snap unset ...` instead of `snap set ...`, we don't need to append the `!` exclamation point to the end of the key name. Whoopsies :cold_face:
* `ConfigurationManager` now takes a string in its constructor rather than a `ServiceType`. This makes it much easier to create configuration managers for slurmctld components such as `cgroup` and `acct_gather`. I realized that `ConfigurationManager` only needs `config_name`, so there's no need to actually pass the full `ServiceType` enum.