### PR TITLE
feat: add prometheus exporter manager

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -84,7 +84,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = ["pyyaml>=6.0.1"]

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -180,6 +180,7 @@ class ServiceType(Enum):
     """Type of Slurm service to manage."""
 
     MUNGED = "munged"
+    PROMETHEUS_EXPORTER = "slurm-prometheus-exporter"
     SLURMD = "slurmd"
     SLURMCTLD = "slurmctld"
     SLURMDBD = "slurmdbd"
@@ -285,6 +286,13 @@ class MungeManager(ServiceManager):
         _mungectl("key", "generate")
 
 
+class PrometheusExporterManager(ServiceManager):
+    """Manage `slurm-prometheus-exporter` service operations."""
+
+    def __init__(self) -> None:
+        self._service = ServiceType.PROMETHEUS_EXPORTER
+
+
 class SlurmManagerBase(ServiceManager):
     """Base manager for Slurm services."""
 
@@ -292,6 +300,7 @@ class SlurmManagerBase(ServiceManager):
         self._service = service
         self.config = ConfigurationManager(service.config_name)
         self.munge = MungeManager()
+        self.exporter = PrometheusExporterManager()
 
     @property
     def hostname(self) -> str:


### PR DESCRIPTION
Adds the `PrometheusExporterManager` class for managing the operations of the Slurm prometheus exporter bundled with the Slurm snap.

`PrometheusExporterManager` inherits from `ServiceManager` so that it can enable, disable, and restart the exporter service. The exporter is exposed through the `exporter` attribute of `SlurmManagerBase`. This way we can use something like the following block of code to turn on the exporter after we have connected a COS deployment to Charmed HPC:

```python3
def _on_integration(self, _: Event) -> None:
    """Handler for when COS is integrated into cluster."""
    # staging operations for setting up observability.
    ...
    self._manager.exporter.enable()
```

One thing we'll likely need to do in the future is that once we determine how we want to configure the prometheus exporter, we'll need to expose a config interface.

Fixes #19 