### PR TITLE
fix: remove `decode` inside `_call`

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -103,8 +103,8 @@ def _call(cmd: str, *args: str, stdin: Optional[str] = None) -> str:
         return subprocess.check_output(cmd, input=stdin, stderr=subprocess.PIPE, text=True).strip()
     except subprocess.CalledProcessError as e:
         _logger.error(f"`{' '.join(cmd)}` failed")
-        _logger.error(f"stderr: {e.stderr.decode()}")
-        raise SlurmOpsError(f"command {cmd[0]} failed. reason:\n{e.stderr.decode()}")
+        _logger.error(f"stderr: {e.stderr}")
+        raise SlurmOpsError(f"command {cmd[0]} failed. reason:\n{e.stderr}")
 
 
 def _snap(*args) -> str:

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -109,7 +109,7 @@ class TestSnapPackageManager(FsTestCase):
 
     def test_call_error(self, subcmd) -> None:
         """Test that `slurm_ops` propagates errors when a command fails."""
-        subcmd.side_effect = subprocess.CalledProcessError(-1, cmd=[""], stderr=b"error")
+        subcmd.side_effect = subprocess.CalledProcessError(-1, cmd=[""], stderr="error")
         with self.assertRaises(slurm.SlurmOpsError):
             self.manager.install()
 


### PR DESCRIPTION
Fixes a bug where the script would throw when `check_output` throws an error, since the returned `stderr` would be a str instead of bytes.