### PR TITLE
feat: abstract around base package manager

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,10 @@
+# lib deps
+slurmutils ~= 0.6.0
+python-dotenv ~= 1.0.1
+pyyaml >= 6.0.2
+
+# tests deps
+coverage[toml] ~= 7.6
+pyfakefs ~= 5.6.0
 pytest ~= 7.2
 pytest-order ~= 1.1

--- a/tests/integration/slurm_ops/test_manager.py
+++ b/tests/integration/slurm_ops/test_manager.py
@@ -3,69 +3,70 @@
 # See LICENSE file for licensing details.
 
 import base64
+from pathlib import Path
 
 import pytest
 
-import lib.charms.hpc_libs.v0.slurm_ops as slurm
-from lib.charms.hpc_libs.v0.slurm_ops import ServiceType, SlurmManagerBase
+from lib.charms.hpc_libs.v0.slurm_ops import SlurmctldManager
 
 
 @pytest.fixture
-def slurmctld() -> SlurmManagerBase:
-    return SlurmManagerBase(ServiceType.SLURMCTLD)
+def slurmctld() -> SlurmctldManager:
+    return SlurmctldManager(snap=True)
 
 
 @pytest.mark.order(1)
-def test_install(slurmctld: SlurmManagerBase) -> None:
+def test_install(slurmctld: SlurmctldManager) -> None:
     """Install Slurm using the manager."""
-    slurm.install()
-    slurmctld.munge.generate_key()
+    slurmctld.install()
+    slurmctld.munge.key.generate()
 
     with open("/var/snap/slurm/common/etc/munge/munge.key", "rb") as f:
         key: str = base64.b64encode(f.read()).decode()
 
-    assert key == slurmctld.munge.get_key()
+    assert key == slurmctld.munge.key.get()
 
 
 @pytest.mark.order(2)
-def test_rotate_key(slurmctld: SlurmManagerBase) -> None:
+def test_rotate_key(slurmctld: SlurmctldManager) -> None:
     """Test that the munge key can be rotated."""
-    old_key = slurmctld.munge.get_key()
-    slurmctld.munge.generate_key()
-    new_key = slurmctld.munge.get_key()
+    old_key = slurmctld.munge.key.get()
+    slurmctld.munge.key.generate()
+    new_key = slurmctld.munge.key.get()
     assert old_key != new_key
 
 
 @pytest.mark.order(3)
-def test_slurm_config(slurmctld: SlurmManagerBase) -> None:
+def test_slurm_config(slurmctld: SlurmctldManager) -> None:
     """Test that the slurm config can be changed."""
-    slurmctld.config.set({"slurmctld-host": "test-slurm-ops", "cluster-name": "test-cluster"})
-    value = slurmctld.config.get("cluster-name")
-    assert value == "test-cluster"
+    with slurmctld.config() as config:
+        config.slurmctld_host = ["test-slurm-ops"]
+        config.cluster_name = "test-cluster"
 
-    with open("/var/snap/slurm/common/etc/slurm/slurm.conf", "r") as f:
-        output = f.read()
+    print(Path("/var/snap/slurm/common/etc/slurm/slurm.conf").read_text())
 
-    for line in output.splitlines():
+    for line in Path("/var/snap/slurm/common/etc/slurm/slurm.conf").read_text().splitlines():
         entry = line.split("=")
         if len(entry) != 2:
             continue
         key, value = entry
         if key == "ClusterName":
             assert value == "test-cluster"
+        if key == "SlurmctldHost":
+            assert value == "test-slurm-ops"
 
 
 @pytest.mark.order(4)
-def test_enable_service(slurmctld: SlurmManagerBase) -> None:
+def test_enable_service(slurmctld: SlurmctldManager) -> None:
     """Test that the slurmctl daemon can be enabled."""
-    slurmctld.enable()
-    assert slurmctld.active()
+    slurmctld.service.enable()
+    assert slurmctld.service.active()
 
 
 @pytest.mark.order(5)
-def test_version() -> None:
+def test_version(slurmctld: SlurmctldManager) -> None:
     """Test that the Slurm manager can report its version."""
-    version = slurm.version()
+    version = slurmctld.version()
 
     # We are interested in knowing that this does not return a falsy value (`None`, `''`, `[]`, etc.)
     assert version

--- a/tox.ini
+++ b/tox.ini
@@ -42,15 +42,14 @@ commands =
     # if this charm owns a lib, uncomment "lib_path" variable
     # and uncomment the following line
     # codespell {[vars]lib_path}
-    codespell {tox_root}
+    codespell {tox_root} -L assertIn
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests
 deps =
-    pytest
-    coverage[toml]
+    -r {tox_root}/dev-requirements.txt
     -r {tox_root}/requirements.txt
 commands =
     coverage run --source={[vars]lib_path} \


### PR DESCRIPTION
This PR abstracts around the base package manager used.

The objective of this is to enable switching between snap packages and deb packages in a more composable way. 