### PR TITLE
chore(vbump): bump LIBPATCH version to 7

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -99,7 +99,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = ["pyyaml>=6.0.2", "python-dotenv~=1.0.1", "slurmutils~=0.6.0", "distro~=1.9.0"]


### PR DESCRIPTION
Bumps the LIBPATCH version of `slurm_ops` to 7. Now that we have the deb manager and correct prometheus exporter service name, we can go zooooom in the Slurm charms with COS.