### PR TITLE
feat(slurm_ops): add `scontrol` and clean up public exports

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -566,6 +566,15 @@ class _SlurmManagerBase:
         """The hostname where this manager is running."""
         return socket.gethostname().split(".")[0]
 
+    @staticmethod
+    def scontrol(*args) -> str:
+        """Control Slurm via `scontrol` commands.
+
+        Raises:
+            SlurmOpsError: Raised if scontrol command fails.
+        """
+        return _call("scontrol", *args).stdout
+
 
 class SlurmctldManager(_SlurmManagerBase):
     """Manager for the Slurmctld service."""

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -13,13 +13,13 @@ from unittest.mock import patch
 import charms.hpc_libs.v0.slurm_ops as slurm
 import dotenv
 from charms.hpc_libs.v0.slurm_ops import (
-    ServiceType,
     SlurmctldManager,
     SlurmdbdManager,
     SlurmdManager,
-    SlurmManagerBase,
     SlurmOpsError,
-    SnapManager,
+    _ServiceType,
+    _SlurmManagerBase,
+    _SnapManager,
 )
 from pyfakefs.fake_filesystem_unittest import TestCase as FsTestCase
 
@@ -86,7 +86,7 @@ class TestSlurmOps(TestCase):
 )
 class TestSnapPackageManager(FsTestCase):
     def setUp(self):
-        self.manager = SnapManager()
+        self.manager = _SnapManager()
         self.setUpPyfakefs()
         self.fs.create_file("/var/snap/slurm/common/.env")
 
@@ -213,10 +213,10 @@ class SlurmOpsBase:
 
 
 parameters = [
-    (SlurmManagerBase(ServiceType.SLURMCTLD, snap=True), "slurm"),
-    (SlurmManagerBase(ServiceType.SLURMD, snap=True), "slurmd"),
-    (SlurmManagerBase(ServiceType.SLURMDBD, snap=True), "slurmdbd"),
-    (SlurmManagerBase(ServiceType.SLURMRESTD, snap=True), "slurmrestd"),
+    (_SlurmManagerBase(_ServiceType.SLURMCTLD, snap=True), "slurm"),
+    (_SlurmManagerBase(_ServiceType.SLURMD, snap=True), "slurmd"),
+    (_SlurmManagerBase(_ServiceType.SLURMDBD, snap=True), "slurmdbd"),
+    (_SlurmManagerBase(_ServiceType.SLURMRESTD, snap=True), "slurmrestd"),
 ]
 
 for manager, config_name in parameters:

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -6,6 +6,7 @@
 
 import base64
 import subprocess
+import textwrap
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
@@ -211,6 +212,12 @@ class SlurmOpsBase:
         gethostname.return_value = "machine.domain.com"
         self.assertEqual(self.manager.hostname, "machine")
 
+    def test_scontrol(self, subcmd) -> None:
+        """Test that manager correctly calls scontrol."""
+        self.manager.scontrol("reconfigure")
+        args = subcmd.call_args[0][0]
+        self.assertEqual(args, ["scontrol", "reconfigure"])
+
 
 parameters = [
     (_SlurmManagerBase(_ServiceType.SLURMCTLD, snap=True), "slurm"),
@@ -235,55 +242,58 @@ for manager, config_name in parameters:
 class TestSlurmctldConfig(FsTestCase):
     """Test the Slurmctld service config manager."""
 
-    EXAMPLE_SLURM_CONF = """#
-# `slurm.conf` file generated at 2024-01-30 17:18:36.171652 by slurmutils.
-#
-SlurmctldHost=juju-c9fc6f-0(10.152.28.20)
-SlurmctldHost=juju-c9fc6f-1(10.152.28.100)
+    EXAMPLE_SLURM_CONF = textwrap.dedent(
+        """
+        #
+        # `slurm.conf` file generated at 2024-01-30 17:18:36.171652 by slurmutils.
+        #
+        SlurmctldHost=juju-c9fc6f-0(10.152.28.20)
+        SlurmctldHost=juju-c9fc6f-1(10.152.28.100)
 
-ClusterName=charmed-hpc
-AuthType=auth/munge
-Epilog=/usr/local/slurm/epilog
-Prolog=/usr/local/slurm/prolog
-FirstJobId=65536
-InactiveLimit=120
-JobCompType=jobcomp/filetxt
-JobCompLoc=/var/log/slurm/jobcomp
-KillWait=30
-MaxJobCount=10000
-MinJobAge=3600
-PluginDir=/usr/local/lib:/usr/local/slurm/lib
-ReturnToService=0
-SchedulerType=sched/backfill
-SlurmctldLogFile=/var/log/slurm/slurmctld.log
-SlurmdLogFile=/var/log/slurm/slurmd.log
-SlurmctldPort=7002
-SlurmdPort=7003
-SlurmdSpoolDir=/var/spool/slurmd.spool
-StateSaveLocation=/var/spool/slurm.state
-SwitchType=switch/none
-TmpFS=/tmp
-WaitTime=30
+        ClusterName=charmed-hpc
+        AuthType=auth/munge
+        Epilog=/usr/local/slurm/epilog
+        Prolog=/usr/local/slurm/prolog
+        FirstJobId=65536
+        InactiveLimit=120
+        JobCompType=jobcomp/filetxt
+        JobCompLoc=/var/log/slurm/jobcomp
+        KillWait=30
+        MaxJobCount=10000
+        MinJobAge=3600
+        PluginDir=/usr/local/lib:/usr/local/slurm/lib
+        ReturnToService=0
+        SchedulerType=sched/backfill
+        SlurmctldLogFile=/var/log/slurm/slurmctld.log
+        SlurmdLogFile=/var/log/slurm/slurmd.log
+        SlurmctldPort=7002
+        SlurmdPort=7003
+        SlurmdSpoolDir=/var/spool/slurmd.spool
+        StateSaveLocation=/var/spool/slurm.state
+        SwitchType=switch/none
+        TmpFS=/tmp
+        WaitTime=30
 
-#
-# Node configurations
-#
-NodeName=juju-c9fc6f-2 NodeAddr=10.152.28.48 CPUs=1 RealMemory=1000 TmpDisk=10000
-NodeName=juju-c9fc6f-3 NodeAddr=10.152.28.49 CPUs=1 RealMemory=1000 TmpDisk=10000
-NodeName=juju-c9fc6f-4 NodeAddr=10.152.28.50 CPUs=1 RealMemory=1000 TmpDisk=10000
-NodeName=juju-c9fc6f-5 NodeAddr=10.152.28.51 CPUs=1 RealMemory=1000 TmpDisk=10000
+        #
+        # Node configurations
+        #
+        NodeName=juju-c9fc6f-2 NodeAddr=10.152.28.48 CPUs=1 RealMemory=1000 TmpDisk=10000
+        NodeName=juju-c9fc6f-3 NodeAddr=10.152.28.49 CPUs=1 RealMemory=1000 TmpDisk=10000
+        NodeName=juju-c9fc6f-4 NodeAddr=10.152.28.50 CPUs=1 RealMemory=1000 TmpDisk=10000
+        NodeName=juju-c9fc6f-5 NodeAddr=10.152.28.51 CPUs=1 RealMemory=1000 TmpDisk=10000
 
-#
-# Down node configurations
-#
-DownNodes=juju-c9fc6f-5 State=DOWN Reason="Maintenance Mode"
+        #
+        # Down node configurations
+        #
+        DownNodes=juju-c9fc6f-5 State=DOWN Reason="Maintenance Mode"
 
-#
-# Partition configurations
-#
-PartitionName=DEFAULT MaxTime=30 MaxNodes=10 State=UP
-PartitionName=batch Nodes=juju-c9fc6f-2,juju-c9fc6f-3,juju-c9fc6f-4,juju-c9fc6f-5 MinNodes=4 MaxTime=120 AllowGroups=admin
-"""
+        #
+        # Partition configurations
+        #
+        PartitionName=DEFAULT MaxTime=30 MaxNodes=10 State=UP
+        PartitionName=batch Nodes=juju-c9fc6f-2,juju-c9fc6f-3,juju-c9fc6f-4,juju-c9fc6f-5 MinNodes=4 MaxTime=120 AllowGroups=admin
+        """
+    ).strip()
 
     def setUp(self):
         self.manager = SlurmctldManager(snap=True)
@@ -327,41 +337,44 @@ PartitionName=batch Nodes=juju-c9fc6f-2,juju-c9fc6f-3,juju-c9fc6f-4,juju-c9fc6f-
 class TestSlurmdbdConfig(FsTestCase):
     """Test the Slurmdbd service config manager."""
 
-    EXAMPLE_SLURMDBD_CONF = """#
-# `slurmdbd.conf` file generated at 2024-01-30 17:18:36.171652 by slurmutils.
-#
-ArchiveEvents=yes
-ArchiveJobs=yes
-ArchiveResvs=yes
-ArchiveSteps=no
-ArchiveTXN=no
-ArchiveUsage=no
-ArchiveScript=/usr/sbin/slurm.dbd.archive
-AuthInfo=/var/run/munge/munge.socket.2
-AuthType=auth/munge
-AuthAltTypes=auth/jwt
-AuthAltParameters=jwt_key=16549684561684@
-DbdHost=slurmdbd-0
-DbdBackupHost=slurmdbd-1
-DebugLevel=info
-PluginDir=/all/these/cool/plugins
-PurgeEventAfter=1month
-PurgeJobAfter=12month
-PurgeResvAfter=1month
-PurgeStepAfter=1month
-PurgeSuspendAfter=1month
-PurgeTXNAfter=12month
-PurgeUsageAfter=24month
-LogFile=/var/log/slurmdbd.log
-PidFile=/var/run/slurmdbd.pid
-SlurmUser=slurm
-StoragePass=supersecretpasswd
-StorageType=accounting_storage/mysql
-StorageUser=slurm
-StorageHost=127.0.0.1
-StoragePort=3306
-StorageLoc=slurm_acct_db
-"""
+    EXAMPLE_SLURMDBD_CONF = textwrap.dedent(
+        """
+        #
+        # `slurmdbd.conf` file generated at 2024-01-30 17:18:36.171652 by slurmutils.
+        #
+        ArchiveEvents=yes
+        ArchiveJobs=yes
+        ArchiveResvs=yes
+        ArchiveSteps=no
+        ArchiveTXN=no
+        ArchiveUsage=no
+        ArchiveScript=/usr/sbin/slurm.dbd.archive
+        AuthInfo=/var/run/munge/munge.socket.2
+        AuthType=auth/munge
+        AuthAltTypes=auth/jwt
+        AuthAltParameters=jwt_key=16549684561684@
+        DbdHost=slurmdbd-0
+        DbdBackupHost=slurmdbd-1
+        DebugLevel=info
+        PluginDir=/all/these/cool/plugins
+        PurgeEventAfter=1month
+        PurgeJobAfter=12month
+        PurgeResvAfter=1month
+        PurgeStepAfter=1month
+        PurgeSuspendAfter=1month
+        PurgeTXNAfter=12month
+        PurgeUsageAfter=24month
+        LogFile=/var/log/slurmdbd.log
+        PidFile=/var/run/slurmdbd.pid
+        SlurmUser=slurm
+        StoragePass=supersecretpasswd
+        StorageType=accounting_storage/mysql
+        StorageUser=slurm
+        StorageHost=127.0.0.1
+        StoragePort=3306
+        StorageLoc=slurm_acct_db
+        """
+    ).strip()
 
     def setUp(self):
         self.manager = SlurmdbdManager(snap=True)


### PR DESCRIPTION
This PR adds the static method `scontrol` to `_SlurmManagerBase`, and it cleans up the public exports of the slurm_ops charm library to just be `SlurmctldManager`, `SlurmdManager`, `SlurmdbdManager`, `SlurmrestdManager`, and `SlurmOpsError`.

Closes #29 