### PR TITLE
fix(slurm_ops): ensure that all slurm daemons are installed

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -461,7 +461,15 @@ class _AptManager(_OpsManager):
         repositories.add(experimental)
 
         apt.update()
-        for package in ["slurm-wlm", "mungectl", "prometheus-slurm-exporter"]:
+        for package in [
+            "slurmctld",
+            "slurmd",
+            "slurmdbd",
+            "slurmrestd",
+            "slurm-client",
+            "mungectl",
+            "prometheus-slurm-exporter",
+        ]:
             try:
                 apt.add_package(package)
             except apt.PackageNotFoundError as e:


### PR DESCRIPTION
This PR ensures that all the Slurm daemons are installed on the host with the necessary client commands. This mimics the behavior of the Slurm snap where all the daemons are installed but are controlled through orchestration with the charms. This also helps that our version of Slurm is consistent across all machines since Slurm doesn't guarantee backwards compatibility between daemon versions.

Fixes #28 