### PR TITLE
feat(slurm_ops): add cgroup configuration manager

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # lib deps
-slurmutils ~= 0.6.0
+slurmutils ~= 0.7.0
 python-dotenv ~= 1.0.1
 pyyaml >= 6.0.2
 distro ~=1.9.0

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -152,10 +152,7 @@ def _systemctl(*args) -> str:
     Raises:
         SlurmOpsError: Raised if systemctl command fails.
     """
-    return _call(
-        "systemctl",
-        *args,
-    ).stdout
+    return _call("systemctl", *args).stdout
 
 
 def _mungectl(*args, stdin: Optional[str] = None) -> str:

--- a/tests/integration/slurm_ops/test_manager.py
+++ b/tests/integration/slurm_ops/test_manager.py
@@ -26,9 +26,6 @@ def test_install(slurmctld: SlurmctldManager, etc_path: Path) -> None:
     assert key == slurmctld.munge.key.get()
 
 
-"sz+VRDLFlr3o"
-
-
 @pytest.mark.order(2)
 def test_rotate_key(slurmctld: SlurmctldManager) -> None:
     """Test that the munge key can be rotated."""
@@ -39,13 +36,13 @@ def test_rotate_key(slurmctld: SlurmctldManager) -> None:
 
 
 @pytest.mark.order(3)
-def test_slurm_config(slurmctld: SlurmctldManager, etc_path: Path) -> None:
+def test_slurm_config(slurmctld: SlurmctldManager) -> None:
     """Test that the slurm config can be changed."""
-    with slurmctld.config() as config:
+    with slurmctld.config.edit() as config:
         config.slurmctld_host = [slurmctld.hostname]
         config.cluster_name = "test-cluster"
 
-    for line in (etc_path / "slurm" / "slurm.conf").read_text().splitlines():
+    for line in str(slurmctld.config.load()).splitlines():
         entry = line.split("=")
         if len(entry) != 2:
             continue
@@ -58,7 +55,7 @@ def test_slurm_config(slurmctld: SlurmctldManager, etc_path: Path) -> None:
 
 @pytest.mark.order(4)
 def test_enable_service(slurmctld: SlurmctldManager) -> None:
-    """Test that the slurmctl daemon can be enabled."""
+    """Test that the slurmctld daemon can be enabled."""
     slurmctld.service.enable()
     assert slurmctld.service.active()
 


### PR DESCRIPTION
This PR enhances the configuration management interface and adds a configuration manager for the _cgroup.conf_ file. The configuration management interface is extended by adding the `load` and `dump` methods which make it much easier to build abstractions around the various configuration files on the machines.

Also includes some various quality of life fixes such as removing a random string that we had in the integration tests, minor documentation and formatting fixes here and there.

Closes #31 