### PR TITLE
feat(slurm_ops): implement initial jwt key manager

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ slurmutils ~= 0.7.0
 python-dotenv ~= 1.0.1
 pyyaml >= 6.0.2
 distro ~=1.9.0
+cryptography ~= 43.0.1
 
 # tests deps
 coverage[toml] ~= 7.6

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -621,8 +621,8 @@ class _AptManager(_OpsManager):
 class _JWTKeyManager:
     """Control the jwt signing key used by Slurm."""
 
-    def __init__(self, keyfile: Path) -> None:
-        self._keyfile = keyfile
+    def __init__(self, ops_manager: _OpsManager) -> None:
+        self._keyfile = ops_manager.var_lib_path / "slurm.state/jwt_hs256.key"
 
     def get(self) -> str:
         """Get the current jwt key."""
@@ -693,7 +693,7 @@ class _SlurmManagerBase:
         self._ops_manager = _SnapManager() if snap else _AptManager(service)
         self.service = self._ops_manager.service_manager_for(service)
         self.munge = _MungeManager(self._ops_manager)
-        self.jwt = _JWTKeyManager(self._ops_manager.var_lib_path / "slurm.data/jwt_hs256.key")
+        self.jwt = _JWTKeyManager(self._ops_manager)
         self.exporter = _PrometheusExporterManager(self._ops_manager)
         self.install = self._ops_manager.install
         self.version = self._ops_manager.version

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -418,9 +418,13 @@ class _SnapManager(_OpsManager):
 
     def install(self) -> None:
         """Install Slurm using the `slurm` snap."""
-        # FIXME: Pin slurm to the stable channel
+        # TODO: https://github.com/charmed-hpc/hpc-libs/issues/35 -
+        # Pin Slurm snap to stable channel.
         _snap("install", "slurm", "--channel", "latest/candidate", "--classic")
-        # FIXME: Request automatic alias for `mungectl` so that we don't need to do this manually
+        # TODO: https://github.com/charmed-hpc/slurm-snap/issues/49 -
+        # Request automatic alias for the Slurm snap so we don't need to do it here.
+        # We will possibly need to account for a third-party Slurm snap installation
+        # where aliasing is not automatically performed.
         _snap("alias", "slurm.mungectl", "mungectl")
 
     def version(self) -> str:
@@ -610,14 +614,12 @@ class _AptManager(_OpsManager):
         return _EnvManager(file=self._env_file, prefix=type.value)
 
 
+# TODO: https://github.com/charmed-hpc/hpc-libs/issues/36 -
+# Use `jwtctl` to provide backend for generating, setting, and getting
+# jwt signing key used by `slurmctld` and `slurmdbd`. This way we also
+# won't need to pass the keyfile path to the `__init__` constructor.
 class _JWTKeyManager:
-    """Control the JWT key used by Slurm.
-
-    Todo:
-        Use `jwtctl` to provide backend for generating, setting, and getting
-        JWT key used by `slurmctld` and `slurmrestd`. This way we won't need to
-        pass the `snap` bool as an argument to `__init__`
-    """
+    """Control the jwt signing key used by Slurm."""
 
     def __init__(self, keyfile: Path) -> None:
         self._keyfile = keyfile

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -162,10 +162,10 @@ class SlurmOpsBase:
         self.setUpPyfakefs()
         self.fs.create_file("/var/snap/slurm/common/.env")
         self.fs.create_file("/var/snap/slurm/common/var/lib/slurm/slurm.state/jwt_hs256.key")
-        self.manager.jwt._keyfile_path = Path(
+        self.manager.jwt._keyfile = Path(
             "/var/snap/slurm/common/var/lib/slurm/slurm.state/jwt_hs256.key"
         )
-        self.manager.jwt._keyfile_path.write_text(JWT_KEY)
+        self.manager.jwt._keyfile.write_text(JWT_KEY)
 
     def test_config_name(self, *_) -> None:
         """Test that the config name is correctly set."""

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -7,6 +7,7 @@
 import base64
 import subprocess
 import textwrap
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -160,9 +161,11 @@ class SlurmOpsBase:
     def setUp(self):
         self.setUpPyfakefs()
         self.fs.create_file("/var/snap/slurm/common/.env")
-        self.fs.create_file(
-            "/var/snap/slurm/common/var/lib/slurm/slurm.state/jwt_hs256.key", contents=JWT_KEY
+        self.fs.create_file("/var/snap/slurm/common/var/lib/slurm/slurm.state/jwt_hs256.key")
+        self.manager.jwt._keyfile_path = Path(
+            "/var/snap/slurm/common/var/lib/slurm/slurm.state/jwt_hs256.key"
         )
+        self.manager.jwt._keyfile_path.write_text(JWT_KEY)
 
     def test_config_name(self, *_) -> None:
         """Test that the config name is correctly set."""


### PR DESCRIPTION
This PR introduces initial support for managing JWT keys within `slurm_ops`. It's similar to the `_MungeKeyManager` class, but with the exception that it uses the [`cryptography`](https://cryptography.io/en/latest/) module to generate the key rather than a dedicated tool. Ideally we'll eventually use a dedicated tool - something like `jwtctl` - but that's for next cycle.

Also, this PR makes the small change of generating a `StateSaveLocation` directory for Slurm. The Debian package doesn't do this, so after install the `_AptManager` will create the `var/lib/slurm/slurm.state` directory that can be used for stashing the key and then exporting across the cluster. There doesn't seem to be an agreed upon standard, so I just chose the dirname `slurm.state` since it's clear that this is the directory where the slurm daemons will save their state. The snap uses `checkpoint` as the name, but we can easily change this.

Closes #10 