### PR TITLE
fix: format -> fmt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = format, lint, static, unit
+env_list = fmt, lint, static, unit
 min_version = 4.0.0
 
 [vars]
@@ -23,8 +23,8 @@ pass_env =
     CHARM_BUILD_DIR
     MODEL_SETTINGS
 
-[testenv:format]
-description = Apply coding style standards to code
+[testenv:fmt]
+description = Apply coding style standards to code.
 deps =
     black
     ruff
@@ -33,7 +33,7 @@ commands =
     ruff check --fix {[vars]all_path}
 
 [testenv:lint]
-description = Check code against coding style standards
+description = Check code against coding style standards.
 deps =
     black
     ruff
@@ -47,7 +47,7 @@ commands =
     black --check --diff {[vars]all_path}
 
 [testenv:unit]
-description = Run unit tests
+description = Run unit tests.
 deps =
     -r {tox_root}/dev-requirements.txt
     -r {tox_root}/requirements.txt
@@ -62,7 +62,7 @@ commands =
     coverage report
 
 [testenv:static]
-description = Run static type checks
+description = Run static type checks.
 deps =
     pyright
     -r {tox_root}/requirements.txt
@@ -70,7 +70,7 @@ commands =
     pyright {posargs}
 
 [testenv:integration]
-description = Run integration tests
+description = Run integration tests.
 allowlist_externals = gambol
 commands =
     gambol -v run tests/integration/test_hpc_libs.yaml


### PR DESCRIPTION
All of the Charmed HPC tox instances use `fmt`, not `format`. Switching back to `fmt` to that devx is consistent across Charmed HPC repos.

Misc. changes:

- Add periods to the end of each environment description.

Also, this PR highlights that we need to put together a spec for what HPC team tox files should look like. Should make some time at either leading up to roadmap or during the engineering sprint when we have the team together in-person.