### PR TITLE
feat(slurm_ops): set correct permissions on files owned by Slurm

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # lib deps
-slurmutils ~= 0.7.0
+slurmutils ~= 0.8.0
 python-dotenv ~= 1.0.1
 pyyaml >= 6.0.2
 distro ~=1.9.0

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -103,7 +103,7 @@ PYDEPS = [
     "cryptography~=43.0.1",
     "pyyaml>=6.0.2",
     "python-dotenv~=1.0.1",
-    "slurmutils~=0.7.0",
+    "slurmutils~=0.8.0",
     "distro~=1.9.0",
 ]
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -727,6 +727,8 @@ class _JWTKeyManager:
         )
 
 
+# TODO: https://github.com/charmed-hpc/mungectl/issues/5 -
+#  Have `mungectl` set user and group permissions on the munge.key file.
 class _MungeKeyManager:
     """Control the munge key via `mungectl ...` commands."""
 

--- a/tests/integration/test_hpc_libs.yaml
+++ b/tests/integration/test_hpc_libs.yaml
@@ -59,6 +59,12 @@ acts:
           apt install -y python3-venv python3-yaml
           python3 -m venv venv --system-site-packages
           venv/bin/python3 -m pip install -r dev-requirements.txt
+      - name: "Create slurm user"
+        run: |
+          groupadd --gid 64030 slurm
+          adduser \
+            --system --gid 64030 --uid 64030 \
+            --no-create-home --home /nonexistent slurm
       - name: "Run `slurm_ops` integration tests"
         run: |
           PYTHONPATH=./lib \

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -5,6 +5,9 @@
 """Test slurm_ops library."""
 
 import base64
+import grp
+import os
+import pwd
 import subprocess
 import textwrap
 from pathlib import Path
@@ -162,9 +165,13 @@ class SlurmOpsBase:
         self.setUpPyfakefs()
         self.fs.create_file("/var/snap/slurm/common/.env")
         self.fs.create_file("/var/snap/slurm/common/var/lib/slurm/slurm.state/jwt_hs256.key")
+
+        # pyfakefs inconsistently mocks JWTKeyManager so manually mock instead.
         self.manager.jwt._keyfile = Path(
             "/var/snap/slurm/common/var/lib/slurm/slurm.state/jwt_hs256.key"
         )
+        self.manager.jwt._user = pwd.getpwuid(os.getuid()).pw_name
+        self.manager.jwt._group = grp.getgrgid(os.getgid()).gr_name
         self.manager.jwt._keyfile.write_text(JWT_KEY)
 
     def test_config_name(self, *_) -> None:


### PR DESCRIPTION
This PR enables the `slurm_ops` lib to correctly set the user, group, and mode on files owned by Slurm. Originally, we had everything owned by `root` which isn't _bad_, but it's encourage that files like _slurm.conf_ and _jwt_hs256.key_ are owned by the dedicated system user `slurm` instead.

The PR adds public `user` and `group` properties that (a) be used to retrieve the `user` and `group` for configuration options such as `SlurmUser` and (b) pushes down to the configuration managers so that `slurmutils` can assign the proper access permissions to the configuration files.

Currently a draft because this PR needs PR https://github.com/charmed-hpc/slurmutils/pull/24 to land since it introduces the mode, user, and group setting features to slurmutils.