### PR TITLE
feat(slurm_ops): loosen environment variable rules and configure openfile limits

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -482,7 +482,7 @@ class _AptManager(_OpsManager):
         self._install_service()
         # Debian package postinst hook does not create a `StateSaveLocation` directory
         # so we make one here that is only r/w by owner.
-        _logger.debug("creating slurm statesavelocation directory")
+        _logger.debug("creating slurm `StateSaveLocation` directory")
         Path("/var/lib/slurm/slurm.state").mkdir(mode=0o600, exist_ok=True)
         self._apply_overrides()
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -413,11 +413,11 @@ class _OpsManager(ABC):
         """Get the path to the Slurm variable state data directory."""
 
     @abstractmethod
-    def service_manager_for(self, type: _ServiceType) -> _ServiceManager:
+    def service_manager_for(self, service: _ServiceType) -> _ServiceManager:
         """Return the `ServiceManager` for the specified `ServiceType`."""
 
     @abstractmethod
-    def env_manager_for(self, type: _ServiceType) -> _EnvManager:
+    def env_manager_for(self, service: _ServiceType) -> _EnvManager:
         """Return the `_EnvManager` for the specified `ServiceType`."""
 
 
@@ -454,11 +454,11 @@ class _SnapManager(_OpsManager):
         """Get the path to the Slurm variable state data directory."""
         return Path("/var/snap/slurm/common/var/lib/slurm")
 
-    def service_manager_for(self, type: _ServiceType) -> _ServiceManager:
+    def service_manager_for(self, service: _ServiceType) -> _ServiceManager:
         """Return the `ServiceManager` for the specified `ServiceType`."""
-        return _SnapServiceManager(type)
+        return _SnapServiceManager(service)
 
-    def env_manager_for(self, type: _ServiceType) -> _EnvManager:
+    def env_manager_for(self, service: _ServiceType) -> _EnvManager:
         """Return the `_EnvManager` for the specified `ServiceType`."""
         return _EnvManager(file="/var/snap/slurm/common/.env")
 
@@ -677,11 +677,11 @@ class _AptManager(_OpsManager):
         """Get the path to the Slurm variable state data directory."""
         return Path("/var/lib/slurm")
 
-    def service_manager_for(self, type: _ServiceType) -> _ServiceManager:
+    def service_manager_for(self, service: _ServiceType) -> _ServiceManager:
         """Return the `ServiceManager` for the specified `ServiceType`."""
-        return _SystemctlServiceManager(type)
+        return _SystemctlServiceManager(service)
 
-    def env_manager_for(self, type: _ServiceType) -> _EnvManager:
+    def env_manager_for(self, service: _ServiceType) -> _EnvManager:
         """Return the `_EnvManager` for the specified `ServiceType`."""
         return _EnvManager(file=self._env_file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ log_cli_level = "INFO"
 # Formatting tools configuration
 [tool.black]
 line-length = 99
-target-version = ["py38"]
+target-version = ["py310"]
 
 # Linting tools configuration
 [tool.ruff]

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -519,6 +519,21 @@ class TestSlurmdbdConfig(FsTestCase):
         self.assertEqual(f_info.st_uid, FAKE_USER_UID)
         self.assertEqual(f_info.st_gid, FAKE_GROUP_GID)
 
+    def test_mysql_unix_port(self, *_) -> None:
+        """Test that `MYSQL_UNIX_PORT` is configured correctly."""
+        self.manager.mysql_unix_port = "/var/snap/charmed-mysql/common/run/mysqlrouter/mysql.sock"
+        self.assertEqual(
+            self.manager.mysql_unix_port,
+            "/var/snap/charmed-mysql/common/run/mysqlrouter/mysql.sock",
+        )
+        self.assertEqual(
+            dotenv.get_key("/var/snap/slurm/common/.env", "MYSQL_UNIX_PORT"),
+            "/var/snap/charmed-mysql/common/run/mysqlrouter/mysql.sock",
+        )
+
+        del self.manager.mysql_unix_port
+        self.assertIsNone(self.manager.mysql_unix_port)
+
 
 @patch("charms.hpc_libs.v0.slurm_ops.subprocess.run")
 class TestSlurmdConfig(FsTestCase):


### PR DESCRIPTION
This PR adds support for setting the `MYSQL_UNIX_PORT` environment variable needed by slurmdbd to connect to MySQL via a unix socket, and it adds configs for expanding the allowed amount open files at once.

This PR also improves the testing coverage of `_AptManager` by mocking several of the installation steps such as configuring apt to use the Ubuntu HPC PPA, writing security configurations, overriding service files, etc. It refactors the install function to (a) lower the cyclomatic complexity of `install` - less if/else in a single function - and (b) very easy to unit test.

### Misc.

* Configure black's target version to be py310 so that we can use match/case. [Python 3.8 is also EOL](https://endoflife.date/python), and we're not targeting any bases that use Python 3.8 by default.
* Simplify unit tests by using only one `TestCase` class. `pyfakefs`'s version of `TestCase` inherits from `unittest.TestCase`, so just don't call `self.setupPyfakeFS()` and it's pretty much the same :sweat: 

## Related issues

* Closes #43 
* Closes #41 