### PR TITLE
fix(slurm_ops): implement feedback from slurm-charms PR #35

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -482,7 +482,7 @@ class _AptManager(_OpsManager):
         self._install_service()
         # Debian package postinst hook does not create a `StateSaveLocation` directory
         # so we make one here that is only r/w by owner.
-        _logger.debug("creating slurm statesavelocation directory")
+        _logger.debug("creating slurm `StateSaveLocation` directory")
         Path("/var/lib/slurm/slurm.state").mkdir(mode=0o600, exist_ok=True)
         self._apply_overrides()
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -177,7 +177,7 @@ def _mungectl(*args, stdin: Optional[str] = None) -> str:
 class _ServiceType(Enum):
     """Type of Slurm service to manage."""
 
-    MUNGED = "munged"
+    MUNGE = "munge"
     PROMETHEUS_EXPORTER = "prometheus-slurm-exporter"
     SLURMD = "slurmd"
     SLURMCTLD = "slurmctld"
@@ -189,8 +189,6 @@ class _ServiceType(Enum):
         """Configuration name on the slurm snap for this service type."""
         if self is _ServiceType.SLURMCTLD:
             return "slurm"
-        if self is _ServiceType.MUNGED:
-            return "munge"
 
         return self.value
 
@@ -864,7 +862,7 @@ class _MungeManager:
     """Manage `munged` service operations."""
 
     def __init__(self, ops_manager: _OpsManager) -> None:
-        self.service = ops_manager.service_manager_for(_ServiceType.MUNGED)
+        self.service = ops_manager.service_manager_for(_ServiceType.MUNGE)
         self.key = _MungeKeyManager()
 
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -637,12 +637,14 @@ class _AptManager(_OpsManager):
         Raises:
             SlurmOpsError: Raised if `apt` fails to install the required Slurm packages.
         """
-        packages = [self._service_name, "mungectl", "prometheus-slurm-exporter"]
+        packages = [self._service_name, "munge", "mungectl", "prometheus-slurm-exporter"]
         match self._service_name:
             case "slurmctld":
                 packages.extend(["libpmix-dev", "mailutils"])
             case "slurmd":
                 packages.extend(["libpmix-dev", "openmpi-bin"])
+            case "slurmrestd":
+                packages.extend(["slurm-wlm-basic-plugins"])
             case _:
                 _logger.debug(
                     "'%s' does not require any additional packages to be installed",

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -103,7 +103,7 @@ PYDEPS = [
     "cryptography~=43.0.1",
     "pyyaml>=6.0.2",
     "python-dotenv~=1.0.1",
-    "slurmutils~=0.8.0",
+    "slurmutils~=0.8.3",
     "distro~=1.9.0",
 ]
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -96,7 +96,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [


### PR DESCRIPTION
This PR implements the necessary fixes needed for `slurm_ops` to unblock https://github.com/charmed-hpc/slurm-charms/pull/35. The PR also bumps the `LIBPATCH` version to `8`.

### Related issues

* Fixes #52 
* Fixes #51 
* Fixes #50 
* Fixes #49 
* Fixes #48
* Fixes #47 
* Fixes #46