### PR TITLE
feat(slurm_ops)!: implement SackdManager for `sackd` service

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -635,10 +635,10 @@ class _AptManager(_OpsManager):
         Raises:
             SlurmOpsError: Raised if `apt` fails to install the required Slurm packages.
         """
-        packages = [self._service_name, "munge", "mungectl", "prometheus-slurm-exporter"]
+        packages = [self._service_name, "munge", "mungectl"]
         match self._service_name:
             case "slurmctld":
-                packages.extend(["libpmix-dev", "mailutils"])
+                packages.extend(["libpmix-dev", "mailutils", "prometheus-slurm-exporter"])
             case "slurmd":
                 packages.extend(["libpmix-dev", "openmpi-bin"])
             case "slurmrestd":

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -51,6 +51,7 @@ class ApplicationCharm(CharmBase):
 """
 
 __all__ = [
+    "SackdManager",
     "SlurmOpsError",
     "SlurmctldManager",
     "SlurmdManager",
@@ -179,6 +180,7 @@ class _ServiceType(Enum):
 
     MUNGE = "munge"
     PROMETHEUS_EXPORTER = "prometheus-slurm-exporter"
+    SACKD = "sackd"
     SLURMD = "slurmd"
     SLURMCTLD = "slurmctld"
     SLURMDBD = "slurmdbd"
@@ -425,12 +427,12 @@ class _SnapManager(_OpsManager):
     def install(self) -> None:
         """Install Slurm using the `slurm` snap."""
         # TODO: https://github.com/charmed-hpc/hpc-libs/issues/35 -
-        #  Pin Slurm snap to stable channel.
+        #   Pin Slurm snap to stable channel.
         _snap("install", "slurm", "--channel", "latest/candidate", "--classic")
         # TODO: https://github.com/charmed-hpc/slurm-snap/issues/49 -
-        #  Request automatic alias for the Slurm snap so we don't need to do it here.
-        #  We will possibly need to account for a third-party Slurm snap installation
-        #  where aliasing is not automatically performed.
+        #   Request automatic alias for the Slurm snap so we don't need to do it here.
+        #   We will possibly need to account for a third-party Slurm snap installation
+        #   where aliasing is not automatically performed.
         _snap("alias", "slurm.mungectl", "mungectl")
 
     def version(self) -> str:
@@ -514,49 +516,6 @@ class _AptManager(_OpsManager):
             SlurmOpsError: Raised if `apt` fails to update with Ubuntu HPC repositories enabled.
         """
         _logger.debug("initializing apt to use ubuntu hpc debian package repositories")
-        slurm_wlm = apt.DebianRepository(
-            enabled=True,
-            repotype="deb",
-            uri="https://ppa.launchpadcontent.net/ubuntu-hpc/slurm-wlm-23.02/ubuntu",
-            release=distro.codename(),
-            groups=["main"],
-        )
-        slurm_wlm.import_key(
-            textwrap.dedent(
-                """
-                -----BEGIN PGP PUBLIC KEY BLOCK-----
-                Comment: Hostname:
-                Version: Hockeypuck 2.2
-
-                xsFNBGTuZb8BEACtJ1CnZe6/hv84DceHv+a54y3Pqq0gqED0xhTKnbj/E2ByJpmT
-                NlDNkpeITwPAAN1e3824Me76Qn31RkogTMoPJ2o2XfG253RXd67MPxYhfKTJcnM3
-                CEkmeI4u2Lynh3O6RQ08nAFS2AGTeFVFH2GPNWrfOsGZW03Jas85TZ0k7LXVHiBs
-                W6qonbsFJhshvwC3SryG4XYT+z/+35x5fus4rPtMrrEOD65hij7EtQNaE8owuAju
-                Kcd0m2b+crMXNcllWFWmYMV0VjksQvYD7jwGrWeKs+EeHgU8ZuqaIP4pYHvoQjag
-                umqnH9Qsaq5NAXiuAIAGDIIV4RdAfQIR4opGaVgIFJdvoSwYe3oh2JlrLPBlyxyY
-                dayDifd3X8jxq6/oAuyH1h5K/QLs46jLSR8fUbG98SCHlRmvozTuWGk+e07ALtGe
-                sGv78ToHKwoM2buXaTTHMwYwu7Rx8LZ4bZPHdersN1VW/m9yn1n5hMzwbFKy2s6/
-                D4Q2ZBsqlN+5aW2q0IUmO+m0GhcdaDv8U7RVto1cWWPr50HhiCi7Yvei1qZiD9jq
-                57oYZVqTUNCTPxi6NeTOdEc+YqNynWNArx4PHh38LT0bqKtlZCGHNfoAJLPVYhbB
-                b2AHj9edYtHU9AAFSIy+HstET6P0UDxy02IeyE2yxoUBqdlXyv6FL44E+wARAQAB
-                zRxMYXVuY2hwYWQgUFBBIGZvciBVYnVudHUgSFBDwsGOBBMBCgA4FiEErocSHcPk
-                oLD4H/Aj9tDF1ca+s3sFAmTuZb8CGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AA
-                CgkQ9tDF1ca+s3sz3w//RNawsgydrutcbKf0yphDhzWS53wgfrs2KF1KgB0u/H+u
-                6Kn2C6jrVM0vuY4NKpbEPCduOj21pTCepL6PoCLv++tICOLVok5wY7Zn3WQFq0js
-                Iy1wO5t3kA1cTD/05v/qQVBGZ2j4DsJo33iMcQS5AjHvSr0nu7XSvDDEE3cQE55D
-                87vL7lgGjuTOikPh5FpCoS1gpemBfwm2Lbm4P8vGOA4/witRjGgfC1fv1idUnZLM
-                TbGrDlhVie8pX2kgB6yTYbJ3P3kpC1ZPpXSRWO/cQ8xoYpLBTXOOtqwZZUnxyzHh
-                gM+hv42vPTOnCo+apD97/VArsp59pDqEVoAtMTk72fdBqR+BB77g2hBkKESgQIEq
-                EiE1/TOISioMkE0AuUdaJ2ebyQXugSHHuBaqbEC47v8t5DVN5Qr9OriuzCuSDNFn
-                6SBHpahN9ZNi9w0A/Yh1+lFfpkVw2t04Q2LNuupqOpW+h3/62AeUqjUIAIrmfeML
-                IDRE2VdquYdIXKuhNvfpJYGdyvx/wAbiAeBWg0uPSepwTfTG59VPQmj0FtalkMnN
-                ya2212K5q68O5eXOfCnGeMvqIXxqzpdukxSZnLkgk40uFJnJVESd/CxHquqHPUDE
-                fy6i2AnB3kUI27D4HY2YSlXLSRbjiSxTfVwNCzDsIh7Czefsm6ITK2+cVWs0hNQ=
-                =cs1s
-                -----END PGP PUBLIC KEY BLOCK-----
-                """
-            )
-        )
         experimental = apt.DebianRepository(
             enabled=True,
             repotype="deb",
@@ -601,7 +560,6 @@ class _AptManager(_OpsManager):
             )
         )
         repositories = apt.RepositoryMapping()
-        repositories.add(slurm_wlm)
         repositories.add(experimental)
 
         try:
@@ -637,6 +595,8 @@ class _AptManager(_OpsManager):
         """
         packages = [self._service_name, "munge", "mungectl"]
         match self._service_name:
+            case "sackd":
+                packages.extend(["slurm-client"])
             case "slurmctld":
                 packages.extend(["libpmix-dev", "mailutils", "prometheus-slurm-exporter"])
             case "slurmd":
@@ -674,6 +634,28 @@ class _AptManager(_OpsManager):
     def _apply_overrides(self) -> None:
         """Override defaults supplied provided by Slurm Debian packages."""
         match self._service_name:
+            case "sackd":
+                _logger.debug("overriding default sackd service configuration")
+                config_override = Path(
+                    "/etc/systemd/system/sackd.service.d/10-sackd-config-server.conf"
+                )
+                config_override.mkdir(parents=True, exist_ok=True)
+                config_override.write_text(
+                    textwrap.dedent(
+                        """
+                        [Service]
+                        ExecStart=
+                        ExecStart=/usr/bin/sh -c "/usr/sbin/sackd --systemd $${SACKD_CONFIG_SERVER:+--conf-server $$SACKD_CONFIG_SERVER} $$SACKD_OPTIONS"
+                        """
+                    )
+                )
+
+                # TODO: https://github.com/charmed-hpc/hpc-libs/issues/54 -
+                #   Make `sackd` create its service environment file so that we
+                #   aren't required to manually create it here.
+                _logger.debug("creating sackd environment file")
+                self._env_file.touch(mode=0o644)
+                dotenv.set_key(self._env_file, "SACKD_OPTIONS", "")
             case "slurmctld":
                 _logger.debug("overriding default slurmctld service configuration")
                 self._set_ulimit()
@@ -792,11 +774,11 @@ class _AptManager(_OpsManager):
 
 
 # TODO: https://github.com/charmed-hpc/hpc-libs/issues/36 -
-#  Use `jwtctl` to provide backend for generating, setting, and getting
-#  jwt signing key used by `slurmctld` and `slurmdbd`. This way we also
-#  won't need to pass the keyfile path to the `__init__` constructor.
-#  .
-#  Also, enable `jwtctl` to set the user and group for the keyfile.
+#   Use `jwtctl` to provide backend for generating, setting, and getting
+#   jwt signing key used by `slurmctld` and `slurmdbd`. This way we also
+#   won't need to pass the keyfile path to the `__init__` constructor.
+#   .
+#   Also, enable `jwtctl` to set the user and group for the keyfile.
 class _JWTKeyManager:
     """Control the jwt signing key used by Slurm."""
 
@@ -828,7 +810,7 @@ class _JWTKeyManager:
 
 
 # TODO: https://github.com/charmed-hpc/mungectl/issues/5 -
-#  Have `mungectl` set user and group permissions on the munge.key file.
+#   Have `mungectl` set user and group permissions on the munge.key file.
 class _MungeKeyManager:
     """Control the munge key via `mungectl ...` commands."""
 
@@ -906,6 +888,29 @@ class _SlurmManagerBase:
             SlurmOpsError: Raised if scontrol command fails.
         """
         return _call("scontrol", *args).stdout
+
+
+class SackdManager(_SlurmManagerBase):
+    """Manager for the Sackd service."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(service=_ServiceType.SACKD, *args, **kwargs)
+        self._env_manager = self._ops_manager.env_manager_for(_ServiceType.SACKD)
+
+    @property
+    def config_server(self) -> str:
+        """Get the config server address of this Sackd node."""
+        return self._env_manager.get("SACKD_CONFIG_SERVER")
+
+    @config_server.setter
+    def config_server(self, addr: str) -> None:
+        """Set the config server address of this Sackd node."""
+        self._env_manager.set({"SACKD_CONFIG_SERVER": addr})
+
+    @config_server.deleter
+    def config_server(self) -> None:
+        """Unset the config server address of this Sackd node."""
+        self._env_manager.unset("SACKD_CONFIG_SERVER")
 
 
 class SlurmctldManager(_SlurmManagerBase):

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -97,11 +97,11 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [
-    "cryptography~=43.0.1",
+    "cryptography~=44.0.0",
     "pyyaml>=6.0.2",
     "python-dotenv~=1.0.1",
     "slurmutils~=0.9.0",

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -912,9 +912,10 @@ class SackdManager(_SlurmManagerBase):
         self._env_manager = self._ops_manager.env_manager_for(_ServiceType.SACKD)
 
     @property
-    def config_server(self) -> str:
+    def config_server(self) -> str | None:
         """Get the configuration server address of this `sackd` node."""
-        return self._env_manager.get("SACKD_CONFIG_SERVER")
+        result = self._env_manager.get("SACKD_CONFIG_SERVER")
+        return None if result == "" else result
 
     @config_server.setter
     def config_server(self, addr: str) -> None:
@@ -971,7 +972,7 @@ class SlurmdManager(_SlurmManagerBase):
         return "root"
 
     @property
-    def config_server(self) -> str:
+    def config_server(self) -> str | None:
         """Get the configuration server address of this `slurmd` node."""
         return self._env_manager.get("SLURMD_CONFIG_SERVER")
 
@@ -1000,7 +1001,7 @@ class SlurmdbdManager(_SlurmManagerBase):
         )
 
     @property
-    def mysql_unix_port(self) -> str:
+    def mysql_unix_port(self) -> str | None:
         """Get the URI of the unix socket `slurmdbd` uses to communicate with MySQL."""
         return self._env_manager.get("MYSQL_UNIX_PORT")
 

--- a/tests/integration/slurm_ops/test_manager.py
+++ b/tests/integration/slurm_ops/test_manager.py
@@ -40,6 +40,7 @@ def test_slurm_config(slurmctld: SlurmctldManager) -> None:
     """Test that the slurm config can be changed."""
     with slurmctld.config.edit() as config:
         config.slurmctld_host = [slurmctld.hostname]
+        config.state_save_location = "/var/lib/slurm/checkpoint"
         config.cluster_name = "test-cluster"
 
     for line in str(slurmctld.config.load()).splitlines():

--- a/tests/integration/test_hpc_libs.yaml
+++ b/tests/integration/test_hpc_libs.yaml
@@ -18,7 +18,7 @@ provider:
 acts:
   test-is-container:
     name: "Test the is_container library"
-    run-on: jammy
+    run-on: noble
     input:
       - host-path: lib
         path: lib
@@ -43,7 +43,7 @@ acts:
             is_container
   test-slurm-ops-snap:
     name: "Test the slurm_ops library (snap)"
-    run-on: jammy
+    run-on: noble
     input:
       - host-path: lib
         path: lib
@@ -76,7 +76,7 @@ acts:
             slurm_ops
   test-slurm-ops-apt:
     name: "Test the slurm_ops library (apt)"
-    run-on: jammy
+    run-on: noble
     input:
       - host-path: lib
         path: lib

--- a/tests/unit/test_slurm_ops.py
+++ b/tests/unit/test_slurm_ops.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import charms.operator_libs_linux.v0.apt as apt
 import dotenv
 from charms.hpc_libs.v0.slurm_ops import (
+    SackdManager,
     SlurmctldManager,
     SlurmdbdManager,
     SlurmdManager,
@@ -272,6 +273,7 @@ class TestAptPackageManager(TestCase):
 
     def setUp(self) -> None:
         self.setUpPyfakefs()
+        self.sackd = SackdManager(snap=False)
         self.slurmctld = SlurmctldManager(snap=False)
         self.slurmd = SlurmdManager(snap=False)
         self.slurmdbd = SlurmdbdManager(snap=False)
@@ -339,7 +341,17 @@ class TestAptPackageManager(TestCase):
     @patch("charms.operator_libs_linux.v0.apt.add_package")
     def test_install_service(self, add_package, *_) -> None:
         """Test that `_install_service` installs the correct packages for each service."""
-        # Install slurmctld.
+        self.sackd._ops_manager._install_service()
+        self.assertListEqual(
+            add_package.call_args[0][0],
+            [
+                "sackd",
+                "munge",
+                "mungectl",
+                "slurm-client",
+            ],
+        )
+
         self.slurmctld._ops_manager._install_service()
         self.assertListEqual(
             add_package.call_args[0][0],
@@ -347,9 +359,9 @@ class TestAptPackageManager(TestCase):
                 "slurmctld",
                 "munge",
                 "mungectl",
-                "prometheus-slurm-exporter",
                 "libpmix-dev",
                 "mailutils",
+                "prometheus-slurm-exporter",
             ],
         )
 
@@ -360,7 +372,6 @@ class TestAptPackageManager(TestCase):
                 "slurmd",
                 "munge",
                 "mungectl",
-                "prometheus-slurm-exporter",
                 "libpmix-dev",
                 "openmpi-bin",
             ],
@@ -369,7 +380,7 @@ class TestAptPackageManager(TestCase):
         self.slurmdbd._ops_manager._install_service()
         self.assertListEqual(
             add_package.call_args[0][0],
-            ["slurmdbd", "munge", "mungectl", "prometheus-slurm-exporter"],
+            ["slurmdbd", "munge", "mungectl"],
         )
 
         self.slurmrestd._ops_manager._install_service()
@@ -379,7 +390,6 @@ class TestAptPackageManager(TestCase):
                 "slurmrestd",
                 "munge",
                 "mungectl",
-                "prometheus-slurm-exporter",
                 "slurm-wlm-basic-plugins",
             ],
         )
@@ -571,6 +581,24 @@ for manager, config_name in parameters:
             "config_name": config_name,
         },
     )
+
+
+@patch("charms.hpc_libs.v0.slurm_ops.subprocess.run")
+class TestSackdConfig(TestCase):
+    """Test the `sackd` service configuration manager."""
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.manager = SackdManager(snap=False)
+        self.fs.create_file("/etc/default/sackd")
+
+    def test_config_server(self, *_) -> None:
+        """Test that `SACKD_CONFIG_SERVER` is configured correctly."""
+        self.manager.config_server = "localhost"
+        self.assertEqual(self.manager.config_server, "localhost")
+        self.assertEqual(dotenv.get_key("/etc/default/sackd", "SACKD_CONFIG_SERVER"), "localhost")
+        del self.manager.config_server
+        self.assertIsNone(self.manager.config_server)
 
 
 @patch("charms.hpc_libs.v0.slurm_ops.subprocess.run")


### PR DESCRIPTION
> This PR is currently a draft because the apt charm library does not work on Noble based machines. Related bug report: https://github.com/canonical/operator-libs-linux/issues/135.
>
> Will do the version bump after apt charm library issues are fixed and the PR has been approved.

This PR introduces the `SackdManager` class which can be used in a downstream sackd-operator to manage the `sackd` service on machines.

BREAKING CHANGES: This PR drops the PPA `ubuntu-hpc/slurm-wlm-23.02` as it doesn't provide a `sackd` package, and the Slurm version that we can pull from Universe on Noble is newer than what is provided by the PPA. The `ubuntu-hpc/slurm-wlm-23.02` PPA also doesn't provide any packages that work on Noble.

Dropping this PPA means that you will now get an older version of Slurm on Jammy machines, but that isn't a huge issue as we're planning to push the Slurm charms to Noble anyway.

### Misc.

Also this PR makes it such that `prometheus-slurm-exporter` is only installed on `slurmctld` machines since the slurmctld operator is the only Slurm charm that currently integrates with COS via the `cos-agent` relation. Helps minimize our install size just a little bit.