### PR TITLE
feat(slurm_ops): add `acct_gather.conf` configuration file editor to `SlurmctldManager`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # lib deps
-slurmutils ~= 0.8.0
+slurmutils ~= 0.9.0
 python-dotenv ~= 1.0.1
 pyyaml >= 6.0.2
 distro ~=1.9.0

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -96,7 +96,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [


### PR DESCRIPTION
This PR adds an attribute for managing the _acct_gather.conf_ configuration file to the `SlurmctldManager` class. This attribute can then be used to handle changes related to configuring an acct_gather plugin from within the slurmctld charm. Having the editor be available will be necessary for re-enabling InfluxDB support in the Slurm charms.

Bumps the version of `slurm_ops` to 0.9.