### PR TITLE
chore(slurm_ops) bump `slurmutils` to `<1.0.0,>=0.11.0`

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -116,7 +116,7 @@ PYDEPS = [
     "cryptography~=44.0.0",
     "pyyaml>=6.0.2",
     "python-dotenv~=1.0.1",
-    "slurmutils~=0.10.0",
+    "slurmutils<1.0.0,>=0.11.0",
     "distro~=1.9.0",
 ]
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -109,7 +109,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [


### PR DESCRIPTION
Updates `PYDEPS` in `slurm_ops` from `"slurmutils~=0.10.0"` to `"slurmutils<1.0.0,>=0.11.0"` so latest `slurmutils` in the 0.x version series is used.

Follows discussion around version bumps needed for the latest GRES file editor.