### PR TITLE
fix(slurm_ops): install `slurm-client` package on slurmd nodes

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -109,7 +109,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -654,7 +654,7 @@ class _AptManager(_OpsManager):
             case "slurmctld":
                 packages.extend(["libpmix-dev", "mailutils", "prometheus-slurm-exporter"])
             case "slurmd":
-                packages.extend(["libpmix-dev", "openmpi-bin"])
+                packages.extend(["slurm-client", "libpmix-dev", "openmpi-bin"])
             case "slurmrestd":
                 packages.extend(["slurm-wlm-basic-plugins"])
             case _:

--- a/tests/integration/slurm_ops/test_manager.py
+++ b/tests/integration/slurm_ops/test_manager.py
@@ -40,6 +40,7 @@ def test_slurm_config(slurmctld: SlurmctldManager) -> None:
     """Test that the slurm config can be changed."""
     with slurmctld.config.edit() as config:
         config.slurmctld_host = [slurmctld.hostname]
+        Path("/var/lib/slurm/checkpoint").mkdir(mode=0o755, parents=True, exist_ok=True)
         config.state_save_location = "/var/lib/slurm/checkpoint"
         config.cluster_name = "test-cluster"
 

--- a/tests/unit/slurm_ops/test_apt.py
+++ b/tests/unit/slurm_ops/test_apt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Unit tests for `apt` operations manager."""
@@ -130,6 +130,7 @@ class TestAptPackageManager(TestCase):
                 "slurmd",
                 "munge",
                 "mungectl",
+                "slurm-client",
                 "libpmix-dev",
                 "openmpi-bin",
             ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = fmt, lint, static, unit
+env_list = fmt, lint, typecheck, unit
 min_version = 4.0.0
 
 [vars]
@@ -24,7 +24,7 @@ pass_env =
     MODEL_SETTINGS
 
 [testenv:fmt]
-description = Apply coding style standards to code.
+description = Apply coding style standards to code
 deps =
     black
     ruff
@@ -33,21 +33,26 @@ commands =
     ruff check --fix {[vars]all_path}
 
 [testenv:lint]
-description = Check code against coding style standards.
+description = Check code against coding style standards
 deps =
     black
     ruff
     codespell
 commands =
-    # if this charm owns a lib, uncomment "lib_path" variable
-    # and uncomment the following line
-    # codespell {[vars]lib_path}
     codespell {tox_root} -L assertIn
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
+[testenv:typecheck]
+description = Run static type checker on code
+deps =
+    pyright
+    -r {tox_root}/requirements.txt
+commands =
+    pyright {posargs}
+
 [testenv:unit]
-description = Run unit tests.
+description = Run unit tests
 deps =
     -r {tox_root}/dev-requirements.txt
     -r {tox_root}/requirements.txt
@@ -62,16 +67,8 @@ commands =
     coverage report
     coverage xml -o cover/coverage.xml
 
-[testenv:static]
-description = Run static type checks.
-deps =
-    pyright
-    -r {tox_root}/requirements.txt
-commands =
-    pyright {posargs}
-
 [testenv:integration]
-description = Run integration tests.
+description = Run integration tests
 allowlist_externals = gambol
 commands =
     gambol -v run tests/integration/test_hpc_libs.yaml


### PR DESCRIPTION
This PR adds the `slurm-client` package to the installed package set for the `SlurmdManager` class. Installing this package on slurmd nodes will enable cluster users and admins to call common commands such as `srun` and `sbatch` from within their workloads.

### Related issues

* Fixes #62 

### Misc.

* Renames the `static` environment in _tox.ini_ to `typecheck`. Brings it forward for our standards for other repositories.