### PR TITLE
slurmdbd service override

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -832,7 +832,7 @@ class _AptManager(_OpsManager):
                         [Service]
                         PermissionsStartOnly=True
                         RuntimeDirectory=slurmdbd
-                        RuntimeDirectoryMode=0755      
+                        RuntimeDirectoryMode=0755
                         PIDFile=/var/run/slurmdbd/slurmdbd.pid
                         """
                     )

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -820,6 +820,25 @@ class _AptManager(_OpsManager):
                         """
                     )
                 )
+            case "slurmdbd":
+                # TODO: https://github.com/charmed-hpc/hpc-libs/issues/39 -
+                #   Make `slurmrestd` package preinst hook create the system user and group
+                #   so that we do not need to do it manually here.
+                _logger.debug("Creating slurmdbd service override.")
+                slurmdbd_service_override = Path(
+                    "/etc/systemd/system/slurmdbd.service.d/10-slurmdbd-exec-pre-pid.conf"
+                )
+                slurmdbd_service_override.parent.mkdir(exist_ok=True, parents=True)
+                slurmdbd_service_override.write_text(
+                    textwrap.dedent(
+                        """
+                        [Service]
+                        ExecPreStart=/bin/mkdir /var/run/slurmdbd
+                        ExecPreStart=/bin/chown slurm /var/run/slurmdbd
+                        PidFile=/var/run/slurmdbd/slurmdbd.pid
+                        """
+                    )
+                )
             case _:
                 _logger.debug("'%s' does not require any overrides", self._service_name)
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -821,9 +821,6 @@ class _AptManager(_OpsManager):
                     )
                 )
             case "slurmdbd":
-                # TODO: https://github.com/charmed-hpc/hpc-libs/issues/39 -
-                #   Make `slurmrestd` package preinst hook create the system user and group
-                #   so that we do not need to do it manually here.
                 _logger.debug("Creating slurmdbd service override.")
                 slurmdbd_service_override = Path(
                     "/etc/systemd/system/slurmdbd.service.d/10-slurmdbd-exec-pre-pid.conf"

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -835,7 +835,7 @@ class _AptManager(_OpsManager):
                         [Service]
                         ExecPreStart=/bin/mkdir /var/run/slurmdbd
                         ExecPreStart=/bin/chown slurm /var/run/slurmdbd
-                        PidFile=/var/run/slurmdbd/slurmdbd.pid
+                        PIDFile=/var/run/slurmdbd/slurmdbd.pid
                         """
                     )
                 )

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -830,8 +830,9 @@ class _AptManager(_OpsManager):
                     textwrap.dedent(
                         """
                         [Service]
-                        ExecPreStart=/bin/mkdir /var/run/slurmdbd
-                        ExecPreStart=/bin/chown slurm /var/run/slurmdbd
+                        PermissionsStartOnly=True
+                        RuntimeDirectory=slurmdbd
+                        RuntimeDirectoryMode=0755      
                         PIDFile=/var/run/slurmdbd/slurmdbd.pid
                         """
                     )


### PR DESCRIPTION
These changes add a slurmdbd service override file that creates a pid directory and changes the permissions to the slurm user.

Fixes: https://github.com/charmed-hpc/slurm-charms/issues/76