### PR TITLE
fix(slurmd): Slurmd restart override

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -838,9 +838,6 @@ class _AptManager(_OpsManager):
                     )
                 )
             case "slurmdbd":
-                # TODO: https://github.com/charmed-hpc/hpc-libs/issues/39 -
-                #   Make `slurmrestd` package preinst hook create the system user and group
-                #   so that we do not need to do it manually here.
                 _logger.debug("Creating slurmdbd service override.")
                 slurmdbd_service_override = Path(
                     "/etc/systemd/system/slurmdbd.service.d/10-slurmdbd-exec-pre-pid.conf"

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -820,6 +820,25 @@ class _AptManager(_OpsManager):
                         """
                     )
                 )
+            case "slurmdbd":
+                # TODO: https://github.com/charmed-hpc/hpc-libs/issues/39 -
+                #   Make `slurmrestd` package preinst hook create the system user and group
+                #   so that we do not need to do it manually here.
+                _logger.debug("Creating slurmdbd service override.")
+                slurmdbd_service_override = Path(
+                    "/etc/systemd/system/slurmdbd.service.d/10-slurmdbd-exec-pre-pid.conf"
+                )
+                slurmdbd_service_override.parent.mkdir(exist_ok=True, parents=True)
+                slurmdbd_service_override.write_text(
+                    textwrap.dedent(
+                        """
+                        [Service]
+                        ExecPreStart=/bin/mkdir /var/run/slurmdbd
+                        ExecPreStart=/bin/chown slurm /var/run/slurmdbd
+                        PidFile=/var/run/slurmdbd/slurmdbd.pid
+                        """
+                    )
+                )
             case _:
                 _logger.debug("'%s' does not require any overrides", self._service_name)
 

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -835,7 +835,7 @@ class _AptManager(_OpsManager):
                         [Service]
                         ExecPreStart=/bin/mkdir /var/run/slurmdbd
                         ExecPreStart=/bin/chown slurm /var/run/slurmdbd
-                        PidFile=/var/run/slurmdbd/slurmdbd.pid
+                        PIDFile=/var/run/slurmdbd/slurmdbd.pid
                         """
                     )
                 )

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -731,7 +731,7 @@ class _AptManager(_OpsManager):
                 self._set_ulimit()
 
                 nofile_override = Path(
-                    "/etc/systemd/system/slurmctld.service.d/10-slurmd-nofile.conf"
+                    "/etc/systemd/system/slurmd.service.d/10-slurmd-nofile.conf"
                 )
                 nofile_override.parent.mkdir(exist_ok=True, parents=True)
                 nofile_override.write_text(
@@ -759,7 +759,7 @@ class _AptManager(_OpsManager):
                 )
 
                 restart_override = Path(
-                    "/etc/systemd/system/slurmctld.service.d/30-slurmd-restart.conf"
+                    "/etc/systemd/system/slurmd.service.d/30-slurmd-restart.conf"
                 )
                 restart_override.parent.mkdir(exist_ok=True, parents=True)
                 restart_override.write_text(

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -757,6 +757,23 @@ class _AptManager(_OpsManager):
                         """
                     )
                 )
+
+                restart_override = Path(
+                    "/etc/systemd/system/slurmctld.service.d/30-slurmd-restart.conf"
+                )
+                restart_override.parent.mkdir(exist_ok=True, parents=True)
+                restart_override.write_text(
+                    textwrap.dedent(
+                        """
+                        [Unit]
+                        StartLimitIntervalSec=90
+                        StartLimitBurst=10
+                        [Service]
+                        Restart=on-failure
+                        RestartSec=10
+                        """
+                    )
+                )
             case "slurmrestd":
                 # TODO: https://github.com/charmed-hpc/hpc-libs/issues/39 -
                 #   Make `slurmrestd` package preinst hook create the system user and group


### PR DESCRIPTION
These changes add the systemd service override file to the slurmd
charm:
"/etc/systemd/system/slurmctld.service.d/30-slurmd-restart.conf"

The override contains the following options:
```
[Unit]
StartLimitIntervalSec=120
StartLimitBurst=10
[Service]
Restart=on-failure
RestartSec=10
```
This configuration tells slurmd to restart on-failure every 10s
for up to 10 times. If the slurmd service restarts more than
10 times in under 120 seconds, the service will not attempt to
start anymore.