### PR TITLE
feat(slurm_ops): have `_ServiceManager` mirror systemctl command API

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -109,7 +109,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [

--- a/tests/integration/slurm_ops/test_manager.py
+++ b/tests/integration/slurm_ops/test_manager.py
@@ -57,8 +57,8 @@ def test_slurm_config(slurmctld: SlurmctldManager) -> None:
 
 @pytest.mark.order(4)
 def test_enable_service(slurmctld: SlurmctldManager) -> None:
-    """Test that the slurmctld daemon can be enabled."""
-    slurmctld.service.enable()
+    """Test that the slurmctld daemon can be started."""
+    slurmctld.service.start()
     assert slurmctld.service.active()
 
 


### PR DESCRIPTION
This PR updates `_ServiceManager` to more closely align with the API of the `systemctl` command. It uses patches from #67 to add the the `start`/`stop` methods, and switch `reload-or-restart` for plain ole `restart`. It also updates the integration tests to use `.start()` to start slurmctld instead of `.enable()`.

@jamesbeedy added you as a co-author of this PR.