### PR TITLE
Expose keyfile and config paths

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -239,6 +239,11 @@ class _ConfigManager(ABC):
         self._user = user
         self._group = group
 
+    @property
+    def path(self) -> Path:
+        """Return the configuration file path."""
+        return Path(self.config_path)
+
     @abstractmethod
     def load(self) -> BaseModel:
         """Load the current configuration from the configuration file."""

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -909,6 +909,11 @@ class _JWTKeyManager:
         self._user = user
         self._group = group
 
+    @property
+    def path(self) -> Path:
+        """Get the current jwt keyfile path."""
+        return self._keyfile
+
     def get(self) -> str:
         """Get the current jwt key."""
         return self._keyfile.read_text()


### PR DESCRIPTION
These changes expose jwt_keyfile path as a public property of the _JWTKeyManager and add a public property to the _ConfigManager to expose the path of the configuration file.