### PR TITLE
chore(slurm_ops): bump `slurm_ops` to 0.16

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ slurmutils ~= 0.10.0
 python-dotenv ~= 1.0.1
 pyyaml >= 6.0.2
 distro ~=1.9.0
-cryptography ~= 43.0.1
+cryptography ~= 44.0.1
 
 # tests deps
 coverage[toml] ~= 7.6

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -110,11 +110,11 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [
-    "cryptography~=44.0.0",
+    "cryptography~=44.0.1",
     "pyyaml>=6.0.2",
     "python-dotenv~=1.0.1",
     "slurmutils<1.0.0,>=0.11.0",


### PR DESCRIPTION
This PR bumps the version of `slurm_ops` to 0.16.

### Related security fixes

Update cryptography to 44.0.1 to mitigate CVE-2024-12797 due to the cryptography wheel from PyPI shipping a statically linked version of OpenSSL.