### PR TITLE
chore(slurm_ops): bump `slurm_ops` to 0.17

### DIFF
--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 # Charm library dependencies to fetch during `charmcraft pack`.
 PYDEPS = [


### PR DESCRIPTION
This PR bumps the LIBPATCH version of `slurm_ops` to 17.