### PR TITLE
feat: Expose CLI arguments for prometheus exporter daemon

### DIFF
--- a/tests/unit/slurm_ops/test_config.py
+++ b/tests/unit/slurm_ops/test_config.py
@@ -197,6 +197,26 @@ class TestConfigManagement(TestCase):
         self.assertEqual(f_info.st_uid, FAKE_USER_UID)
         self.assertEqual(f_info.st_gid, FAKE_GROUP_GID)
 
+    def test_slurmctld_manager_exporter_config(self) -> None:
+        self.fs.create_file("/etc/default/prometheus-slurm-exporter")
+
+        self.assertEqual(self.slurmctld.exporter.args, [])
+
+        self.slurmctld.exporter.args = ["-slurm.cli-fallback", "-slurm.enable-diag"]
+
+        self.assertEqual(
+            self.slurmctld.exporter.args, ["-slurm.cli-fallback", "-slurm.enable-diag"]
+        )
+        self.assertEqual(
+            dotenv.get_key("/etc/default/prometheus-slurm-exporter", "ARGS"),
+            "-slurm.cli-fallback -slurm.enable-diag",
+        )
+
+        del self.slurmctld.exporter.args
+
+        self.assertEqual(self.slurmctld.exporter.args, [])
+        self.assertEqual(dotenv.get_key("/etc/default/prometheus-slurm-exporter", "ARGS"), None)
+
     def test_slurmd_config_server(self) -> None:
         """Test `SlurmdManager` `config_server` descriptors."""
         self.fs.create_file("/etc/default/slurmd")


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Exposes the `ARGS` environment variable for `prometheus-slurm-exporter` to be able to pass arguments to the daemon.
Need to add tests for this.

#### Related Issues, PRs, and Discussions

#77 

## Docs

* [x] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

Documentation was added to the exposed methods themselves.

