### PR TITLE
fix: enable automatic restart of slurmctld in case of failure

### DIFF
--- a/src/hpc_libs/slurm_ops.py
+++ b/src/hpc_libs/slurm_ops.py
@@ -783,6 +783,8 @@ class _AptManager(_OpsManager):
                         [Service]
                         LimitMEMLOCK=infinity
                         LimitNOFILE=1048576
+                        Restart=on-failure
+                        RestartSec=10
                         """
                     )
                 )


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Enable automatic restart of slurmctld on its systemd service file in case of failure, which
could happen if slurmctld tries to query slurmdbd while its backing database is not yet ready.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Only internal change.

