### PR TITLE
fix: call `ruff check --fix` after `ruff format`

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,6 +45,7 @@ upgrade:
 # Apply coding style standards to code
 fmt: lock
     {{uv_run}} ruff format
+    {{uv_run}} ruff check --fix
 
 # Check code against coding style standards
 lint fix="": lock


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the `fmt` recipe of the repository's _justfile_ to call the command `ruff check --fix` after `ruff format`. `ruff format` will format the code similar to black's standards, but it will not perform other fixes such as sorting imports.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

There are no related issues. I noticed while doing some development work that `just fmt` would format the code, but not sort imports which would cause `just lint` to fail. I added `ruff check --fix` so that other quality-of-life auto fixes would be applied when I call `just fmt`.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

These changes are not user facing and perform the expected functionality of formatting the code according to our set lint rules.