### PR TITLE
feat: add the `slurm_oci_runtime` interface

### DIFF
--- a/src/hpc_libs/interfaces/__init__.py
+++ b/src/hpc_libs/interfaces/__init__.py
@@ -12,4 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A collection of libraries for authoring HPC-related Juju charms."""
+"""Integration interfaces for HPC-related Juju charms."""
+
+__all__ = [
+    # From `slurm/common.py`
+    "SlurmctldConnectedEvent",
+    "SlurmctldDisconnectedEvent",
+    # From `slurm/oci_runtime.py`
+    "OCIRunTimeData",
+    "OCIRunTimeDisconnectedEvent",
+    "OCIRunTimeReadyEvent",
+    "OCIRunTimeProvider",
+    "OCIRunTimeRequirer",
+]
+
+from .slurm.common import SlurmctldConnectedEvent, SlurmctldDisconnectedEvent
+from .slurm.oci_runtime import (
+    OCIRunTimeData,
+    OCIRunTimeDisconnectedEvent,
+    OCIRunTimeProvider,
+    OCIRunTimeReadyEvent,
+    OCIRunTimeRequirer,
+)

--- a/src/hpc_libs/interfaces/base.py
+++ b/src/hpc_libs/interfaces/base.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base classes, methods, and utilities for building HPC-related integration interfaces."""
+
+__all__ = ["BaseInterface", "update_app_data"]
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import ops
+
+INTEGRATION_CONTENT_KEY = "data"
+
+
+class BaseInterface(ops.Object):
+    """Base interface for HPC-related integrations.
+
+    Notes:
+        This interface is not intended to be used directly. Child interfaces should inherit
+        from this interface to provide common macros typically used within custom integration
+        interface implementations.
+    """
+
+    def __init__(self, charm: ops.CharmBase, integration_name: str) -> None:
+        super().__init__(charm, integration_name)
+        self.charm = charm
+        self.app = charm.app
+        self.unit = charm.unit
+        self._integration_name = integration_name
+
+    @property
+    def integrations(self) -> list[ops.Relation]:
+        """Get list of integration instances associated with the configured integration name."""
+        return [
+            integration
+            for integration in self.charm.model.relations[self._integration_name]
+            if self._is_integration_active(integration)
+        ]
+
+    def get_integration(self, integration_id: int | None = None) -> ops.Relation | None:
+        """Get integration instance.
+
+        Args:
+            integration_id:
+                ID of integration instance to retrieve. Required if there are
+                multiple integrations of the same name in Juju's database.
+                For example, you must pass the integration ID if multiple
+                `slurmd` partitions exist.
+        """
+        return self.charm.model.get_relation(self._integration_name, integration_id)
+
+    @staticmethod
+    def _is_integration_active(integration: ops.Relation) -> bool:
+        """Check if an integration is active by accessing contained data."""
+        try:
+            _ = repr(integration.data)
+            return True
+        except (RuntimeError, ops.ModelError):
+            return False
+
+
+def update_app_data(
+    app: ops.Application,
+    integration: ops.Relation,
+    data: Mapping[str, Any],
+    *,
+    json_encoder: type[json.JSONEncoder] | None = None,
+) -> None:
+    """Update an application's databag in an integration.
+
+    Args:
+        app: Application to update.
+        integration: Integration holding application's databag.
+        data: Content to update application databag with.
+        json_encoder: Optional json encoder to use for encoding complex data types.
+
+    Raises:
+        ops.RelationDataError: Raised if non-leader unit attempts to update application data.
+    """
+    data = {k: json.dumps(v, cls=json_encoder) for k, v in data.items()}
+    integration.data[app].update(data)

--- a/src/hpc_libs/interfaces/slurm/__init__.py
+++ b/src/hpc_libs/interfaces/slurm/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A collection of libraries for authoring HPC-related Juju charms."""
+"""Integration interfaces for the Slurm workload manager charms."""

--- a/src/hpc_libs/interfaces/slurm/common.py
+++ b/src/hpc_libs/interfaces/slurm/common.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common classes, methods, and utilities shared between Slurm-related integration interfaces."""
+
+__all__ = [
+    "SlurmctldConnectedEvent",
+    "SlurmctldDisconnectedEvent",
+    "SlurmJSONEncoder",
+    "SlurmctldProvider",
+    "SlurmctldRequirer",
+]
+
+import json
+from typing import Any
+
+import ops
+from slurmutils import Model
+
+from ..base import BaseInterface
+
+
+class SlurmJSONEncoder(json.JSONEncoder):
+    """Generic JSON encoder for Slurm-related integration data."""
+
+    def default(self, o: Any) -> Any:  # noqa D102
+        # Serialize Slurm configuration object if it is present.
+        if isinstance(o, Model):
+            return o.dict()
+
+        return super().default(o)
+
+
+class SlurmctldConnectedEvent(ops.RelationEvent):
+    """Event emitted when `slurmctld` is connected to a Slurm-related application."""
+
+
+class SlurmctldDisconnectedEvent(ops.RelationEvent):
+    """Event emitted when `slurmctld` is disconnected from a Slurm-related application."""
+
+
+class _SlurmctldRequirerEvents(ops.CharmEvents):
+    """`slurmctld` requirer events."""
+
+    slurmctld_connected = ops.EventSource(SlurmctldConnectedEvent)
+    slurmctld_disconnected = ops.EventSource(SlurmctldDisconnectedEvent)
+
+
+class SlurmctldProvider(BaseInterface):
+    """Base interface for `slurmctld` providers to consume Slurm service data.
+
+    Notes:
+        This interface is not intended to be used directly. Child interfaces should inherit
+        from this interface so that they can provide `slurmctld` data and consume configuration
+        provide by other Slurm services such as `slurmd` or `slurmdbd`.
+    """
+
+
+class SlurmctldRequirer(BaseInterface):
+    """Base interface for applications to retrieve data provided by `slurmctld`.
+
+    Notes:
+        This interface is not intended to be used directly. Child interfaces should inherit
+        from this is interface to consume data from the Slurm controller `slurmctld` and provide
+        necessary configuration information to `slurmctld`.
+    """
+
+    on = _SlurmctldRequirerEvents()  # type: ignore
+
+    def __init__(self, charm: ops.CharmBase, integration_name: str) -> None:
+        super().__init__(charm, integration_name)
+
+        self.framework.observe(
+            self.charm.on[self._integration_name].relation_created,
+            self._on_relation_created,
+        )
+        self.framework.observe(
+            self.charm.on[self._integration_name].relation_broken,
+            self._on_relation_broken,
+        )
+
+    def _on_relation_created(self, event: ops.RelationCreatedEvent) -> None:
+        """Handle when `slurmctld` is connected to an application."""
+        self.on.slurmctld_connected.emit(event.relation)
+
+    def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
+        """Handle when `slurmctld` is disconnected from an application."""
+        self.on.slurmctld_disconnected.emit(event.relation)

--- a/src/hpc_libs/interfaces/slurm/oci_runtime.py
+++ b/src/hpc_libs/interfaces/slurm/oci_runtime.py
@@ -1,0 +1,169 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration interface implementation for the `slurm_oci_runtime` interface."""
+
+__all__ = [
+    "OCIRunTimeData",
+    "OCIRunTimeDisconnectedEvent",
+    "OCIRunTimeReadyEvent",
+    "OCIRunTimeProvider",
+    "OCIRunTimeRequirer",
+]
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import ops
+from slurmutils import OCIConfig
+
+from hpc_libs.interfaces.base import update_app_data
+from hpc_libs.interfaces.slurm.common import (
+    SlurmctldProvider,
+    SlurmctldRequirer,
+    SlurmJSONEncoder,
+)
+from hpc_libs.utils import leader
+
+
+@dataclass
+class OCIRunTimeData:
+    """Data provided by the OCI runtime.
+
+    Attributes:
+        ociconfig: OCI runtime data in `oci.conf` configuration file format.
+    """
+
+    ociconfig: OCIConfig
+
+
+class OCIRunTimeReadyEvent(ops.RelationEvent):
+    """Event emitted when the OCI runtime application leader is ready.
+
+    Notes:
+        The OCI runtime application leader is "ready" once it is installed on
+        each principal unit and able to share its configuration information
+        required by the Slurm controller `slurmctld`.
+    """
+
+
+class OCIRunTimeDisconnectedEvent(ops.RelationEvent):
+    """Event emitted when the OCI runtime application is disconnected from `slurmctld`."""
+
+
+class _OCIRunTimeRequirerEvents(ops.CharmEvents):
+    """`slurm_oci_runtime` requirer events."""
+
+    oci_runtime_ready = ops.EventSource(OCIRunTimeReadyEvent)
+    oci_runtime_disconnected = ops.EventSource(OCIRunTimeDisconnectedEvent)
+
+
+class OCIRunTimeProvider(SlurmctldRequirer):
+    """Integration interface implementation for `slurm_oci_runtime` providers.
+
+    Notes:
+        This interface should be used on the OCI runtime application leader to
+        provide OCI runtime information to the `slurmctld` application leader.
+    """
+
+    @leader
+    def set_oci_runtime_data(
+        self, data: OCIRunTimeData, /, integration_id: int | None = None
+    ) -> None:
+        """Set OCI runtime data in the `slurm_oci_runtime` application databag.
+
+        Args:
+            data: OCI runtime data to set on an integrations' application databag.
+            integration_id:
+                (Optional) ID of integration to update. If no integration ID is passed,
+                all integrations will be updated.
+
+        Warnings:
+            Only the OCI runtime application leader can set OCI runtime configuration data.
+        """
+        integrations = self.charm.model.relations.get(self._integration_name)
+        if not integrations:
+            return
+
+        if integration_id is not None:
+            integrations = [
+                integration for integration in integrations if integration.id == integration_id
+            ]
+
+        for integration in integrations:
+            update_app_data(self.app, integration, asdict(data), json_encoder=SlurmJSONEncoder)
+
+
+class OCIRunTimeRequirer(SlurmctldProvider):
+    """Integration interface implementation for `slurm_oci_runtime` requirers.
+
+    Notes:
+        This interface should be used on the `slurmctld` application leader
+        retrieve data from the OCI runtime provider and edit the `oci.conf`
+        configuration file.
+    """
+
+    on = _OCIRunTimeRequirerEvents()  # type: ignore
+
+    def __init__(self, charm: ops.CharmBase, integration_name: str) -> None:
+        super().__init__(charm, integration_name)
+
+        self.framework.observe(
+            self.charm.on[self._integration_name].relation_changed,
+            self._on_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[self._integration_name].relation_broken,
+            self._on_relation_broken,
+        )
+
+    @leader
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Handle when data from the OCI runtime application leader is ready."""
+        provider_app = event.relation.app
+
+        if not event.relation.data.get(provider_app):
+            return
+
+        self.on.oci_runtime_ready.emit(event.relation)
+
+    @leader
+    def _on_relation_broken(self, event: OCIRunTimeDisconnectedEvent) -> None:
+        self.on.oci_runtime_disconnected.emit(event.relation)
+
+    def get_oci_runtime_data(
+        self, /, integration: ops.Relation | None = None, integration_id: int | None = None
+    ) -> OCIRunTimeData | None:
+        """Get OCI runtime data from the `slurm_oci_runtime` application databag.
+
+        Args:
+            integration: Integration instance to pull OCI runtime configuration data from.
+            integration_id: Integration ID to pull OCI runtime configuration data from.
+
+        Raises:
+            ops.TooManyRelatedAppsError:
+                Raised if neither `integration` nor `integration_id` are passed as arguments,
+                but require-side application is integrated with multiple OCI runtime applications.
+        """
+        if not integration:
+            integration = self.charm.model.get_relation(self._integration_name, integration_id)
+
+        if not integration:
+            return None
+
+        provider_app_data: dict[str, Any] = dict(integration.data.get(integration.app))  # type: ignore
+        if config := provider_app_data.get("ociconfig"):
+            provider_app_data["ociconfig"] = OCIConfig.from_json(config)
+
+        return OCIRunTimeData(**provider_app_data) if provider_app_data else None

--- a/src/hpc_libs/utils.py
+++ b/src/hpc_libs/utils.py
@@ -12,4 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A collection of libraries for authoring HPC-related Juju charms."""
+"""Utilities for streamlining common operations within HPC-related Juju charms."""
+
+__all__ = ["leader"]
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+import ops
+
+
+def leader(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Only run method if the unit is the application leader, otherwise skip."""
+
+    @wraps(func)
+    def wrapper(charm: ops.CharmBase, *args: Any, **kwargs: Any) -> Any:
+        if not charm.unit.is_leader():
+            return None
+
+        return func(charm, *args, **kwargs)
+
+    return wrapper

--- a/tests/unit/interfaces/oci_runtime/mock_charms.py
+++ b/tests/unit/interfaces/oci_runtime/mock_charms.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mock charms for the `slurm_oci_runtime` interface unit tests."""
+
+import ops
+from ops import Framework
+from slurmutils import OCIConfig
+
+from hpc_libs.interfaces import (
+    OCIRunTimeData,
+    OCIRunTimeDisconnectedEvent,
+    OCIRunTimeProvider,
+    OCIRunTimeReadyEvent,
+    OCIRunTimeRequirer,
+    SlurmctldConnectedEvent,
+)
+
+OCI_RUNTIME_INTEGRATION_NAME = "oci-runtime"
+EXAMPLE_OCI_CONFIG = OCIConfig(
+    ignorefileconfigjson=False,
+    envexclude="^(SLURM_CONF|SLURM_CONF_SERVER)=",
+    runtimeenvexclude="^(SLURM_CONF|SLURM_CONF_SERVER)=",
+    runtimerun="apptainer exec --userns %r %@",
+    runtimekill="kill -s SIGTERM %p",
+    runtimedelete="kill -s SIGKILL %p",
+)
+
+
+class MockOCIRunTimeProviderCharm(ops.CharmBase):
+    """Mock OCI runtime provider charm."""
+
+    def __init__(self, framework: Framework) -> None:
+        super().__init__(framework)
+
+        self._oci_runtime = OCIRunTimeProvider(self, OCI_RUNTIME_INTEGRATION_NAME)
+
+        framework.observe(self._oci_runtime.on.slurmctld_connected, self._on_slurmctld_connected)
+
+    def _on_slurmctld_connected(self, event: SlurmctldConnectedEvent) -> None:
+        self._oci_runtime.set_oci_runtime_data(
+            OCIRunTimeData(ociconfig=EXAMPLE_OCI_CONFIG),
+            integration_id=event.relation.id,
+        )
+
+
+class MockOCIRunTimeRequirerCharm(ops.CharmBase):
+    """Mock OCI runtime requirer charm."""
+
+    def __init__(self, framework: Framework) -> None:
+        super().__init__(framework)
+
+        self._oci_runtime = OCIRunTimeRequirer(self, OCI_RUNTIME_INTEGRATION_NAME)
+
+        framework.observe(
+            self._oci_runtime.on.oci_runtime_ready,
+            self._on_oci_runtime_ready,
+        )
+        framework.observe(
+            self._oci_runtime.on.oci_runtime_disconnected,
+            self._on_oci_runtime_disconnected,
+        )
+
+    def _on_oci_runtime_ready(self, event: OCIRunTimeReadyEvent) -> None:
+        config = self._oci_runtime.get_oci_runtime_data(event.relation)
+        # Assume `remote_app_data` contains `oci.conf` configuration data.
+        assert config.ociconfig.dict() == EXAMPLE_OCI_CONFIG.dict()
+
+    def _on_oci_runtime_disconnected(self, event: OCIRunTimeDisconnectedEvent) -> None: ...

--- a/tests/unit/interfaces/oci_runtime/test_oci_runtime.py
+++ b/tests/unit/interfaces/oci_runtime/test_oci_runtime.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the `slurm_oci_runtime` integration interface implementation."""
+
+from collections import defaultdict
+
+import pytest
+from mock_charms import (
+    EXAMPLE_OCI_CONFIG,
+    OCI_RUNTIME_INTEGRATION_NAME,
+    MockOCIRunTimeProviderCharm,
+    MockOCIRunTimeRequirerCharm,
+)
+from ops import testing
+from slurmutils import OCIConfig
+
+from hpc_libs.interfaces import OCIRunTimeDisconnectedEvent, OCIRunTimeReadyEvent
+
+
+@pytest.fixture(scope="function")
+def provider_ctx() -> testing.Context[MockOCIRunTimeProviderCharm]:
+    return testing.Context(
+        MockOCIRunTimeProviderCharm,
+        meta={
+            "name": "oci-runtime-provides",
+            "provides": {OCI_RUNTIME_INTEGRATION_NAME: {"interface": "slurm_oci_runtime"}},
+        },
+    )
+
+
+@pytest.fixture(scope="function")
+def requirer_ctx() -> testing.Context[MockOCIRunTimeRequirerCharm]:
+    return testing.Context(
+        MockOCIRunTimeRequirerCharm,
+        meta={
+            "name": "oci-runtime-requires",
+            "requires": {OCI_RUNTIME_INTEGRATION_NAME: {"interface": "slurm_oci_runtime"}},
+        },
+    )
+
+
+@pytest.mark.parametrize("leader", (True, False))
+def test_slurmctld_connected_event_handler(provider_ctx, leader) -> None:
+    """Test that an OCI runtime provider correctly sets `oci.conf` data in application data."""
+    oci_runtime_integration_id = 22
+    oci_runtime_integration = testing.Relation(
+        endpoint=OCI_RUNTIME_INTEGRATION_NAME,
+        interface="oci-runtime",
+        id=oci_runtime_integration_id,
+        remote_app_name="slurmctld",
+    )
+
+    state = provider_ctx.run(
+        provider_ctx.on.relation_created(oci_runtime_integration),
+        testing.State(
+            leader=leader,
+            relations={oci_runtime_integration},
+        ),
+    )
+
+    integration = state.get_relation(oci_runtime_integration_id)
+    if leader:
+        # Verify that the leader unit has set `oci.conf` data in `local_app_data`.
+        assert "ociconfig" in integration.local_app_data
+        config = OCIConfig.from_json(integration.local_app_data["ociconfig"])
+        assert config.dict() == EXAMPLE_OCI_CONFIG.dict()
+    else:
+        # Verify that non-leader units have not set anything in `local_app_data`.
+        assert integration.local_app_data == {}
+
+
+@pytest.mark.parametrize("remote_app_data", ({}, {"ociconfig": EXAMPLE_OCI_CONFIG.json()}))
+@pytest.mark.parametrize("leader", (True, False))
+def test_oci_runtime_ready_event_handler(requirer_ctx, leader, remote_app_data) -> None:
+    """Test that an OCI runtime requirer can consume `oci.conf` data from a runtime provider."""
+    oci_runtime_integration_id = 22
+    oci_runtime_integration = testing.Relation(
+        endpoint=OCI_RUNTIME_INTEGRATION_NAME,
+        interface="oci-runtime",
+        id=oci_runtime_integration_id,
+        remote_app_name="oci-runtime-provider",
+        remote_app_data=remote_app_data,
+    )
+
+    requirer_ctx.run(
+        requirer_ctx.on.relation_changed(oci_runtime_integration),
+        testing.State(leader=leader, relations={oci_runtime_integration}),
+    )
+
+    if leader and remote_app_data:
+        # `MockOCIRunTimeRequirerCharm` provides an assertion to check if `remote_app_data`
+        #  can be read correctly to consume `oci.conf` data.
+
+        # Assert that the last event emitted on the `leader` unit is an `OCIRunTimeReadyEvent`.
+        assert isinstance(requirer_ctx.emitted_events[-1], OCIRunTimeReadyEvent)
+
+        # Assert that `OCIRunTimeReadyEvent` was emitted only once.
+        occurred = defaultdict(lambda: 0)
+        for event in requirer_ctx.emitted_events:
+            occurred[type(event)] += 1
+
+        assert occurred[OCIRunTimeReadyEvent] == 1
+
+    else:
+        # Assert that `OCIRunTimeReadyEvent` is never emitted on non-leader units or on the
+        # leader unit if `remote_app_data` is empty - e.g. blank `RelationChangedEvent` emitted
+        # after `slurmctld` and `oci-runtime-provider` are integrated together.
+        assert not any(
+            isinstance(event, OCIRunTimeReadyEvent) for event in requirer_ctx.emitted_events
+        )
+
+
+@pytest.mark.parametrize("leader", (True, False))
+def test_oci_runtime_disconnected_event_handler(requirer_ctx, leader) -> None:
+    """Test that an OCI requirer properly captures when the runtime provider is disconnected."""
+    oci_runtime_integration_id = 22
+    oci_runtime_integration = testing.Relation(
+        endpoint=OCI_RUNTIME_INTEGRATION_NAME,
+        interface="oci-runtime",
+        id=oci_runtime_integration_id,
+        remote_app_name="oci-runtime-provider",
+    )
+
+    requirer_ctx.run(
+        requirer_ctx.on.relation_broken(oci_runtime_integration),
+        testing.State(leader=leader, relations={oci_runtime_integration}),
+    )
+
+    if leader:
+        # Assert that the last event emitted on the `leader` unit is
+        # an `OCIRunTimeDisconnectedEvent`.
+        assert isinstance(requirer_ctx.emitted_events[-1], OCIRunTimeDisconnectedEvent)
+
+        # Assert that `OCIRunTimeDisconnectedEvent` was emitted only once.
+        occurred = defaultdict(lambda: 0)
+        for event in requirer_ctx.emitted_events:
+            occurred[type(event)] += 1
+
+        assert occurred[OCIRunTimeDisconnectedEvent] == 1
+    else:
+        # Assert that `OCIRunTimeDisconnectEvent` is never emitted on non-leader units.
+        assert not any(
+            isinstance(event, OCIRunTimeDisconnectedEvent) for event in requirer_ctx.emitted_events
+        )


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds an implementation of the `slurm_oci_runtime` interface. Changes include:

- Adding building blocks for creating Slurm-related integration interface implementations.
- Adds the class `OCIRunTimeProvider` for applications that provide a Slurm-compatible OCI runtime.
- Adds the class `OCIRunTimeRequirer` for applications that can integration with a Slurm-compatible OCI runtime.
- Adds custom events for signaling when `slurmctld` is connected or disconnected from an application.
- Adds custom events for when an OCI runtime is ready by serving up its configuration information, or when it is disconnected from a requiring application.
- Adds the `leader` decorator for easily signaling that a method should only be executed on the application leader.
- Adds unit tests for verifying the functionality of both the requires and provides side of the `slurm_oci_runtime` integration.

This interface will be used to configure OCI runtimes such as Apptainer with slurmctld through the _oci.conf_ configuration file.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This PR is part of ongoing work to integration OCI runtimes such as Apptainer with the Slurm charms.

## Open questions

Should the new OCI-related integration interface and event names be prefixed with `Slurm` to signal that this OCI implementation is specific to Slurm and really shouldn't be used by non-Slurm charms?

- `OCIRunTimeData` -> `SlurmOCIRunTimeData`
- `OCIRunTimeDisconnectedEvent` -> `SlurmOCIRunTimeDisconnectedEvent`
- `OCIRunTimeReadyEvent` -> `SlurmOCIRunTimeReadyEvent`
- `OCIRunTimeProvider` -> `SlurmOCIRunTimeProvider`
- `OCIRunTimeRequirer` -> `SlurmOCIRunTimeRequirer`

I debated adding Slurm as a common prefix, but I initially decided against it since I thought it might be too pedantic/over-optimizing to account for a hypothetical situation where we have two OCI runtime concepts within Charmed HPC.

Let me know your thoughts here!

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change that will serve as the building block for user facing changes later on.