### PR TITLE
feat: add `refresh` and `StopCharm` utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     # tests deps
     "coverage[toml] ~= 7.6",
     "pyfakefs ~= 5.6.0",
-    "pytest ~= 7.2",
+    "pytest ~= 8.3",
     "pytest-order ~= 1.1",
     "ops-scenario~=7.22",
 

--- a/src/hpc_libs/utils.py
+++ b/src/hpc_libs/utils.py
@@ -14,13 +14,26 @@
 
 """Utilities for streamlining common operations within HPC-related Juju charms."""
 
-__all__ = ["leader"]
+__all__ = ["StopCharm", "leader", "plog", "refresh"]
 
+import logging
+import pprint
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
 
 import ops
+
+_logger = logging.getLogger(__name__)
+
+
+class StopCharm(Exception):  # noqa N818
+    """Exception raised to set high-priority status message."""
+
+    @property
+    def status(self) -> ops.StatusBase:
+        """Get charm status passed as the first argument to this exception."""
+        return self.args[0]
 
 
 def leader(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -29,8 +42,78 @@ def leader(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
     def wrapper(charm: ops.CharmBase, *args: Any, **kwargs: Any) -> Any:
         if not charm.unit.is_leader():
+            _logger.debug(
+                (
+                    "unit '%s' is not the leader of the '%s' application, ",
+                    "skipping run of method `%s.%s`",
+                ),
+                charm.unit.name,
+                charm.app.name,
+                charm.__class__.__name__,
+                func.__name__,
+            )
             return None
 
+        _logger.debug(
+            "unit '%s' is the leader of the '%s' application, running method `%s.%s`",
+            charm.unit.name,
+            charm.app.name,
+            charm.__class__.__name__,
+            func.__name__,
+        )
         return func(charm, *args, **kwargs)
 
     return wrapper
+
+
+def plog(o: object) -> str:
+    """Prettify built-in Python objects for log output."""
+    return pprint.pformat(o, indent=4, sort_dicts=False)
+
+
+def refresh(check: Callable[[ops.CharmBase], ops.StatusBase] | None = None) -> Callable:
+    """Refresh a charm's status after running an event handler.
+
+    Args:
+        check: Optional condition check to run after running method.
+    """
+
+    def decorator(func: Callable[..., None]):
+        @wraps(func)
+        def wrapper(charm: ops.CharmBase, *args: ops.EventBase, **kwargs: Any) -> None:
+            event, *_ = args
+
+            try:
+                func(charm, *args, **kwargs)
+            except StopCharm as e:
+                _logger.debug(
+                    (
+                        "`StopCharm` exception raised while running `%s` event handler `%s.%s` ",
+                        "on unit '%s'. setting status to `%s`",
+                    ),
+                    event.__class__.__name__,
+                    charm.__class__.__name__,
+                    func.__name__,
+                    charm.unit.name,
+                    e.status,
+                )
+                charm.unit.status = e.status
+                return
+
+            if check:
+                _logger.debug(
+                    "running status check function `%s` to determine new status for unit '%s'",
+                    check.__name__,
+                    charm.unit.name,
+                )
+                status = check(charm)
+                _logger.debug(
+                    "new status for unit '%s' determined to be `%s`",
+                    charm.unit.name,
+                    status,
+                )
+                charm.unit.status = status
+
+        return wrapper
+
+    return decorator

--- a/tests/unit/utils/test_refresh.py
+++ b/tests/unit/utils/test_refresh.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the `refresh` utility."""
+
+import ops
+import pytest
+from ops import testing
+
+from hpc_libs.utils import StopCharm, refresh
+
+refresh_no_check_func = refresh()
+refresh = refresh(check=lambda _: ops.ActiveStatus())
+
+
+class MockCharm(ops.CharmBase):
+    """Mock charm for testing the `refresh` decorator."""
+
+    def __init__(self, framework: ops.Framework):
+        super().__init__(framework)
+        framework.observe(self.on.install, self._on_install)
+        framework.observe(self.on.stop, self._on_stop)
+
+    @refresh
+    def _on_install(self, _: ops.InstallEvent) -> None:
+        if not self.unit.is_leader():
+            raise StopCharm(ops.BlockedStatus("more than 1 unit not supported"))
+
+    @refresh_no_check_func
+    def _on_stop(self, _: ops.StopEvent) -> None:
+        ...
+
+
+@pytest.fixture(scope="function")
+def mock_charm_ctx() -> testing.Context[MockCharm]:
+    return testing.Context(
+        MockCharm,
+        meta={
+            "name": "mock-refresh-charm",
+        },
+    )
+
+
+@pytest.mark.parametrize("leader", (True, False))
+def test_refresh(mock_charm_ctx, leader) -> None:
+    """Test that `refresh` correctly updates a unit's status."""
+    state = mock_charm_ctx.run(mock_charm_ctx.on.install(), testing.State(leader=leader))
+
+    if leader:
+        assert state.unit_status == ops.ActiveStatus()
+    else:
+        assert state.unit_status == ops.BlockedStatus("more than 1 unit not supported")
+
+
+def test_refresh_no_check_func(mock_charm_ctx) -> None:
+    """Test that `refresh` does not change a unit's state if no `check` function is provided."""
+    state = mock_charm_ctx.run(mock_charm_ctx.on.stop(), testing.State())
+    assert state.unit_status == ops.UnknownStatus()

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ requires-dist = [
     { name = "ops-scenario", marker = "extra == 'dev'", specifier = "~=7.22" },
     { name = "pyfakefs", marker = "extra == 'dev'", specifier = "~=5.6.0" },
     { name = "pyright", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "~=7.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "~=8.3" },
     { name = "pytest-order", marker = "extra == 'dev'", specifier = "~=1.1" },
     { name = "python-dotenv", specifier = "~=1.0.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -405,6 +405,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.398"
 source = { registry = "https://pypi.org/simple" }
@@ -419,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -427,11 +436,12 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds the `refresh` utility decorator and `StopCharm` exception. `refresh` can be used to either capture raised `StopCharm` exceptions and set the wrapped status as a high-priority status message, or `refresh` can be used to generate a charm-specific refresh decorator that will run a holistic status check at the of each event handler execution. For example:

```python
import ops
from hpc_libs.utils import refresh

custom_refresh = refresh(lambda charm: ops.BlockedStatus() if not charm.slurmctld.service.active() else ops.ActiveStatus())


class SlurmctldOperator(ops.CharmBase):
    
    @custom_refresh
    def _on_start(self, _: ops.StartEvent) -> None:
        ...
```

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

No related issues. This is part of my ongoing work to overhaul the Slurm charm integration interfaces, and it feeds into my ongoing work on the Apptainer operator.

### Other changes

- Added more granular debug log messages to the `leader` decorator. This way we can see if an event handler is being skipped or not.
- Added the `plog` utility. This function just wraps `pprint` to return nicely formatted output for built-in objects when logging. I added this so we can nicely log output for Slurm configuration data as it's read in from integration databags.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user-facing change. This PR is adding more building blocks for our charms. 