### PR TITLE
feat(utils): make `refresh` accept generic types bound to ops.CharmBase

### DIFF
--- a/src/hpc_libs/utils.py
+++ b/src/hpc_libs/utils.py
@@ -71,7 +71,7 @@ def plog(o: object) -> str:
     return pprint.pformat(o, indent=4, sort_dicts=False)
 
 
-def refresh(check: Callable[[ops.CharmBase], ops.StatusBase] | None = None) -> Callable:
+def refresh[T: ops.CharmBase](check: Callable[[T], ops.StatusBase] | None = None) -> Callable:
     """Refresh a charm's status after running an event handler.
 
     Args:
@@ -80,7 +80,7 @@ def refresh(check: Callable[[ops.CharmBase], ops.StatusBase] | None = None) -> C
 
     def decorator(func: Callable[..., None]):
         @wraps(func)
-        def wrapper(charm: ops.CharmBase, *args: ops.EventBase, **kwargs: Any) -> None:
+        def wrapper(charm: T, *args: ops.EventBase, **kwargs: Any) -> None:
             event, *_ = args
 
             try:
@@ -94,7 +94,7 @@ def refresh(check: Callable[[ops.CharmBase], ops.StatusBase] | None = None) -> C
                     event.__class__.__name__,
                     charm.__class__.__name__,
                     func.__name__,
-                    charm.unit.name,
+                    charm.unit.name,  # type: ignore
                     e.status,
                 )
                 charm.unit.status = e.status
@@ -104,12 +104,12 @@ def refresh(check: Callable[[ops.CharmBase], ops.StatusBase] | None = None) -> C
                 _logger.debug(
                     "running status check function `%s` to determine new status for unit '%s'",
                     check.__name__,
-                    charm.unit.name,
+                    charm.unit.name,  # type: ignore
                 )
                 status = check(charm)
                 _logger.debug(
                     "new status for unit '%s' determined to be `%s`",
-                    charm.unit.name,
+                    charm.unit.name,  # type: ignore
                     status,
                 )
                 charm.unit.status = status


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR modifies the `refresh` utility to accept generic types that are bound to `ops.CharmBase`. This modification is required to use "forward references" for annotating the `check` function with a specific charm class rather than the `ops.CharmBase` base class. 

For example, by using a generic annotation on `refresh`, we can pass `SlurmctldCharm` as the type rather than just `ops.CharmBase`:

```python
import ops


def _check_slurmctld(charm: "SlurmctldCharm") -> ops.StatusBase:
    return ops.ActiveStatus() if charm.slurmctld.is_active() else ops.BlockedStatus("charm is cooked my dude")


refresh = refresh(check=_check_slurmctld)
```

Without the generic type, `pyright` will yoke out complaining that the forward reference `"SlurmctldCharm"` is not assignable to `ops.CharmBase`.

Other things of note:

- For some reason, using a generic type bound to `ops.CharmBase` cause IDEs to forget that `ops.Unit` has properties like `name`. This doesn't cause any errors with the static type checker, but my PyCharm instance decided to visit the salty spittoon, so I used the `# type: ignore` directive to make the errors go away.
- I'm using inline generics, which means that `hpc-libs` will only be compatible with Python 3.12 and beyond. This isn't an issue as all our charms only support Noble.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to ongoing work on implementing dynamic nodes within Charmed HPC.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change to satisfy the static type check.

