### PR TITLE
fix(machine/env): support toggling automatic quoting

### DIFF
--- a/src/hpc_libs/machine/env.py
+++ b/src/hpc_libs/machine/env.py
@@ -34,16 +34,18 @@ class EnvManager:
     def __init__(self, file: str | PathLike) -> None:
         self._file = file
 
-    def get(self, key: str) -> str | None:
+    def get(self, key: str, /) -> str | None:
         """Get value of an environment variable in the environment file."""
         return dotenv.get_key(self._file, key.upper())
 
-    def set(self, config: Mapping[str, Any]) -> None:
+    def set(self, config: Mapping[str, Any], /, quote: bool = True) -> None:
         """Set environment variables in the environment file."""
         for key, value in config.items():
-            dotenv.set_key(self._file, key.upper(), str(value))
+            dotenv.set_key(
+                self._file, key.upper(), str(value), quote_mode="always" if quote else "never"
+            )
 
-    def unset(self, key: str) -> None:
+    def unset(self, key: str, /) -> None:
         """Unset an environment variable in the environment file."""
         dotenv.unset_key(self._file, key.upper())
 

--- a/tests/unit/machine/test_env.py
+++ b/tests/unit/machine/test_env.py
@@ -35,9 +35,18 @@ class TestEnvManager:
 
     def test_set(self, env_manager: EnvManager) -> None:
         """Test the `set` method."""
-        env_manager.set({"SLURMD_CONFIG_SERVER": "localhost:6817"})
+        env_manager.set({"SLURMD_OPTIONS": "localhost:6817"})
         with open(ENV_FILE, "rt") as fin:
-            assert fin.read() == "SLURMD_CONFIG_SERVER='localhost:6817'\n"
+            assert fin.read() == "SLURMD_OPTIONS='localhost:6817'\n"
+
+        # Test with automatic quoting disabled.
+        env_manager.set(
+            {"SLURMD_OPTIONS": "--conf 'realmemory=16000 cpus=8 features=dynamic'"}, quote=False
+        )
+        with open(ENV_FILE, "rt") as fin:
+            assert (
+                fin.read() == "SLURMD_OPTIONS=--conf 'realmemory=16000 cpus=8 features=dynamic'\n"
+            )
 
     def test_get(self, env_manager: EnvManager) -> None:
         """Test the `get` method."""


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR modifies the `EnvManager.set(...)` method to allow HPC charm authors to toggle environment variable quoting. Automatic quoting can interfere with important `slurmd` command line options such as `--conf`.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes #99

This fix is needed for the ongoing work in supporting dynamic nodes in Charmed HPC.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This bugfix PR introduces no user-facing changes.