### PR TITLE
feat(errors): add custom `IngressAddressNotFoundError` exception

### DIFF
--- a/src/hpc_libs/errors.py
+++ b/src/hpc_libs/errors.py
@@ -30,3 +30,7 @@ class SnapError(Error):
 
 class SystemdError(Error):
     """Error raised if a `systemd`-related operation fails."""
+
+
+class IngressAddressNotFoundError(Error):
+    """Error raised if a charm is unable to access its ingress address."""


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds the custom `IngressAddressNotFoundError` exception to `hpc_libs`.

This exception is commonly used within charms such as `slurmdbd` and `slurmctld` for getting the public address of units. Moving this exception's definition to `hpc_libs` de-duplicates it's definition within the Slurm charms monorepo, and it reduces the amount of cut-and-paste we'd need to do each time we are required to change the exception's implementation.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- This work is related to our ongoing work to merge HA support and dynamic nodes into Charmed HPC.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change relocation the definition of a common exception used within the Slurm charms.