### PR TITLE
feat(interfaces): modify `Condition` to accept objects bound to `ops.CharmBase`

### DIFF
--- a/src/hpc_libs/interfaces/base.py
+++ b/src/hpc_libs/interfaces/base.py
@@ -38,7 +38,7 @@ from hpc_libs.utils import StopCharm
 _logger = logging.getLogger(__name__)
 
 type ConditionEvaluation = tuple[bool, str]
-type Condition = Callable[[ops.CharmBase], ConditionEvaluation]
+type Condition[T: ops.CharmBase] = Callable[[T], ConditionEvaluation]
 
 
 def update_secret(charm: ops.CharmBase, label: str, content: dict[str, str]) -> ops.Secret:


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the `Condition` type to accept a callable's whose first argument is a generic object bound to `ops.CharmBase`. The original annotation required the first argument to strictly match `ops.CharmBased` which caused `pyright` to freak out if you passed a specific charm type rather than a generic `ops.CharmBase` object. With the updated annotation, we can now pass specific charm types to conditions:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from charm import SlurmctldCharm
    

def new_condition(charm: "SlurmctldCharm") -> ConditionEvaluation: ...
```

Being able to pass specific charm types directly like `SlurmctldCharm` is useful because we can access charm-specific features such as the `SlurmctldManager` for inspecting if `slurmctld` is installed or not. With the old annotation where `charm` had to strictly match `ops.CharmBase`, conditions had to be littered with `# noqa` comments to satisfy `pyright` as `pyright` does not like it when you attempt to access undefined attributes or properties. 

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This PR is related to our ongoing work to enable HA/dynamic nodes in the Slurm charms.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change.

