### PR TITLE
feat: invert condition checks and add granular integration validators

### DIFF
--- a/src/hpc_libs/interfaces/__init__.py
+++ b/src/hpc_libs/interfaces/__init__.py
@@ -20,14 +20,14 @@ __all__ = [
     "ConditionEvaluation",
     "integration_exists",
     "integration_not_exists",
-    "block_when",
-    "wait_when",
+    "block_unless",
+    "wait_unless",
     # From `slurm/common.py`
     "ControllerData",
     "SlurmctldConnectedEvent",
     "SlurmctldDisconnectedEvent",
     "SlurmctldReadyEvent",
-    "controller_not_ready",
+    "controller_ready",
     # From `slurm/oci_runtime.py`
     "OCIRuntimeData",
     "OCIRuntimeDisconnectedEvent",
@@ -45,7 +45,7 @@ __all__ = [
     "SlurmdDisconnectedEvent",
     "SlurmdProvider",
     "SlurmdRequirer",
-    "partition_not_ready",
+    "partition_ready",
     # From `slurm/slurmdbd.py`
     "DatabaseData",
     "SlurmdbdProvider",
@@ -53,7 +53,7 @@ __all__ = [
     "SlurmdbdConnectedEvent",
     "SlurmdbdReadyEvent",
     "SlurmdbdDisconnectedEvent",
-    "database_not_ready",
+    "database_ready",
     # From `slurm/slurmrestd.py`
     "SlurmrestdProvider",
     "SlurmrestdRequirer",
@@ -63,17 +63,17 @@ __all__ = [
 from .base import (
     Condition,
     ConditionEvaluation,
-    block_when,
+    block_unless,
     integration_exists,
     integration_not_exists,
-    wait_when,
+    wait_unless,
 )
 from .slurm.common import (
     ControllerData,
     SlurmctldConnectedEvent,
     SlurmctldDisconnectedEvent,
     SlurmctldReadyEvent,
-    controller_not_ready,
+    controller_ready,
 )
 from .slurm.oci_runtime import (
     OCIRuntimeData,
@@ -94,7 +94,7 @@ from .slurm.slurmd import (
     SlurmdProvider,
     SlurmdReadyEvent,
     SlurmdRequirer,
-    partition_not_ready,
+    partition_ready,
 )
 from .slurm.slurmdbd import (
     DatabaseData,
@@ -103,7 +103,7 @@ from .slurm.slurmdbd import (
     SlurmdbdProvider,
     SlurmdbdReadyEvent,
     SlurmdbdRequirer,
-    database_not_ready,
+    database_ready,
 )
 from .slurm.slurmrestd import (
     SlurmrestdConnectedEvent,

--- a/src/hpc_libs/interfaces/slurm/common.py
+++ b/src/hpc_libs/interfaces/slurm/common.py
@@ -21,7 +21,7 @@ __all__ = [
     "SlurmctldDisconnectedEvent",
     "SlurmctldProvider",
     "SlurmctldRequirer",
-    "controller_not_ready",
+    "controller_ready",
     "encoder",
 ]
 
@@ -101,15 +101,15 @@ class ControllerData:
                 self.slurmconfig[k] = SlurmConfig(v)
 
 
-def controller_not_ready(charm: ops.CharmBase) -> ConditionEvaluation:
+def controller_ready(charm: ops.CharmBase) -> ConditionEvaluation:
     """Check if controller - `slurmctld` - data is available.
 
     Notes:
         - This condition check requires that the charm has a public `slurmctld`
-          attribute that has a public `ready` method.
+          attribute that has a public `is_ready` method.
     """
-    not_ready = not charm.slurmctld.is_ready()  # type: ignore
-    return not_ready, "Waiting for controller data" if not_ready else ""
+    ready = charm.slurmctld.is_ready()  # type: ignore
+    return ConditionEvaluation(ready, "Waiting for controller data" if not ready else "")
 
 
 class SlurmctldConnectedEvent(ops.RelationEvent):

--- a/src/hpc_libs/interfaces/slurm/common.py
+++ b/src/hpc_libs/interfaces/slurm/common.py
@@ -26,7 +26,7 @@ __all__ = [
 ]
 
 import json
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from string import Template
 from typing import Any
@@ -153,8 +153,14 @@ class SlurmctldProvider(Interface):
         integration_name: str,
         *,
         required_app_data: Iterable[str] | None = None,
+        app_data_validator: Callable[[ops.RelationDataContent], bool] | None = None,
     ) -> None:
-        super().__init__(charm, integration_name, required_app_data=required_app_data)
+        super().__init__(
+            charm,
+            integration_name,
+            required_app_data=required_app_data,
+            app_data_validator=app_data_validator,
+        )
 
         self.framework.observe(
             self.charm.on[self._integration_name].relation_broken,
@@ -235,8 +241,14 @@ class SlurmctldRequirer(Interface):
         integration_name: str,
         *,
         required_app_data: Iterable[str] | None = None,
+        app_data_validator: Callable[[ops.RelationDataContent], bool] | None = None,
     ) -> None:
-        super().__init__(charm, integration_name, required_app_data=required_app_data)
+        super().__init__(
+            charm,
+            integration_name,
+            required_app_data=required_app_data,
+            app_data_validator=app_data_validator,
+        )
 
         self.framework.observe(
             self.charm.on[self._integration_name].relation_created,

--- a/src/hpc_libs/interfaces/slurm/slurmd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmd.py
@@ -37,15 +37,16 @@ from hpc_libs.interfaces.slurm.common import (
 )
 from hpc_libs.utils import leader
 
+_REQUIRED_APP_DATA = {
+    "auth_key_id": lambda value: value != '""',
+    "controllers": lambda value: value != "[]",
+    "nhc_args": lambda _: True,
+}
+
 
 def _slurmd_app_data_validator(data: ops.RelationDataContent) -> bool:
     """Validate data sent by `slurmctld` stored in the `slurmd` integration."""
-    return all(
-        (
-            data["auth_key_id"] != '""',
-            data["controllers"] != "[]",
-        )
-    )
+    return all(validate(data[k]) for k, validate in _REQUIRED_APP_DATA.items())
 
 
 @dataclass(frozen=True)
@@ -114,7 +115,7 @@ class SlurmdProvider(SlurmctldRequirer):
         super().__init__(
             charm,
             integration_name,
-            required_app_data={"auth_key_id", "controllers", "nhc_args"},
+            required_app_data=set(_REQUIRED_APP_DATA),
             app_data_validator=_slurmd_app_data_validator,
         )
 

--- a/src/hpc_libs/interfaces/slurm/slurmd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmd.py
@@ -21,7 +21,7 @@ __all__ = [
     "SlurmdDisconnectedEvent",
     "SlurmdProvider",
     "SlurmdRequirer",
-    "partition_not_ready",
+    "partition_ready",
 ]
 
 from dataclasses import dataclass
@@ -52,15 +52,15 @@ class ComputeData:
             object.__setattr__(self, "partition", Partition(self.partition))
 
 
-def partition_not_ready(charm: ops.CharmBase) -> ConditionEvaluation:
+def partition_ready(charm: ops.CharmBase) -> ConditionEvaluation:
     """Check if compute - `slurmd` - data is available.
 
     Notes:
         - This condition check requires that the charm has a public `slurmd`
-          attribute that has a public `ready` method.
+          attribute that has a public `is_ready` method.
     """
-    not_ready = not charm.slurmd.is_ready()  # type: ignore
-    return not_ready, "Waiting for partition data" if not_ready else ""
+    ready = charm.slurmd.is_ready()  # type: ignore
+    return ConditionEvaluation(ready, "Waiting for partition data" if not ready else "")
 
 
 class SlurmdConnectedEvent(ops.RelationEvent):

--- a/src/hpc_libs/interfaces/slurm/slurmd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmd.py
@@ -38,6 +38,16 @@ from hpc_libs.interfaces.slurm.common import (
 from hpc_libs.utils import leader
 
 
+def _slurmd_app_data_validator(data: ops.RelationDataContent) -> bool:
+    """Validate data sent by `slurmctld` stored in the `slurmd` integration."""
+    return all(
+        (
+            data["auth_key_id"] != '""',
+            data["controllers"] != "[]",
+        )
+    )
+
+
 @dataclass(frozen=True)
 class ComputeData:
     """Data provided by the Slurm compute service, `slurmd`."""
@@ -102,7 +112,10 @@ class SlurmdProvider(SlurmctldRequirer):
 
     def __init__(self, charm: ops.CharmBase, /, integration_name: str) -> None:
         super().__init__(
-            charm, integration_name, required_app_data={"auth_key_id", "controllers", "nhc_args"}
+            charm,
+            integration_name,
+            required_app_data={"auth_key_id", "controllers", "nhc_args"},
+            app_data_validator=_slurmd_app_data_validator,
         )
 
     @leader

--- a/src/hpc_libs/interfaces/slurm/slurmdbd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmdbd.py
@@ -21,7 +21,7 @@ __all__ = [
     "SlurmdbdDisconnectedEvent",
     "SlurmdbdProvider",
     "SlurmdbdRequirer",
-    "database_not_ready",
+    "database_ready",
 ]
 
 from dataclasses import dataclass
@@ -45,15 +45,15 @@ class DatabaseData:
     hostname: str = ""
 
 
-def database_not_ready(charm: ops.CharmBase) -> ConditionEvaluation:
+def database_ready(charm: ops.CharmBase) -> ConditionEvaluation:
     """Check if database - `slurmdbd` - data is available.
 
     Notes:
         - This condition check requirers that the charm has a public `slurmdbd`
-          attribute that has a public `ready` method.
+          attribute that has a public `is_ready` method.
     """
-    not_ready = not charm.slurmdbd.is_ready()  # type: ignore
-    return not_ready, "Waiting for database data" if not_ready else ""
+    ready = charm.slurmdbd.is_ready()  # type: ignore
+    return ConditionEvaluation(ready, "Waiting for database data" if not ready else "")
 
 
 class SlurmdbdConnectedEvent(ops.RelationEvent):

--- a/src/hpc_libs/utils.py
+++ b/src/hpc_libs/utils.py
@@ -14,7 +14,7 @@
 
 """Utilities for streamlining common operations within HPC-related Juju charms."""
 
-__all__ = ["StopCharm", "leader", "plog", "refresh", "get_ingress_address"]
+__all__ = ["StopCharm", "get_ingress_address", "leader", "plog", "reconfigure", "refresh"]
 
 import logging
 import pprint
@@ -38,87 +38,9 @@ class StopCharm(Exception):  # noqa N818
         return self.args[0]
 
 
-def leader(func: Callable[..., Any]) -> Callable[..., Any]:
-    """Only run method if the unit is the application leader, otherwise skip."""
-
-    @wraps(func)
-    def wrapper(charm: ops.CharmBase, *args: Any, **kwargs: Any) -> Any:
-        if not charm.unit.is_leader():
-            _logger.debug(
-                (
-                    "unit '%s' is not the leader of the '%s' application, ",
-                    "skipping run of method `%s.%s`",
-                ),
-                charm.unit.name,
-                charm.app.name,
-                charm.__class__.__name__,
-                func.__name__,
-            )
-            return None
-
-        _logger.debug(
-            "unit '%s' is the leader of the '%s' application, running method `%s.%s`",
-            charm.unit.name,
-            charm.app.name,
-            charm.__class__.__name__,
-            func.__name__,
-        )
-        return func(charm, *args, **kwargs)
-
-    return wrapper
-
-
 def plog(o: object) -> str:
     """Prettify built-in Python objects for log output."""
     return pprint.pformat(o, indent=4, sort_dicts=False)
-
-
-def refresh[T: ops.CharmBase](check: Callable[[T], ops.StatusBase] | None = None) -> Callable:
-    """Refresh a charm's status after running an event handler.
-
-    Args:
-        check: Optional condition check to run after running method.
-    """
-
-    def decorator(func: Callable[..., None]):
-        @wraps(func)
-        def wrapper(charm: T, *args: ops.EventBase, **kwargs: Any) -> None:
-            event, *_ = args
-
-            try:
-                func(charm, *args, **kwargs)
-            except StopCharm as e:
-                _logger.debug(
-                    (
-                        "`StopCharm` exception raised while running `%s` event handler `%s.%s` ",
-                        "on unit '%s'. setting status to `%s`",
-                    ),
-                    event.__class__.__name__,
-                    charm.__class__.__name__,
-                    func.__name__,
-                    charm.unit.name,  # type: ignore
-                    e.status,
-                )
-                charm.unit.status = e.status
-                return
-
-            if check:
-                _logger.debug(
-                    "running status check function `%s` to determine new status for unit '%s'",
-                    check.__name__,
-                    charm.unit.name,  # type: ignore
-                )
-                status = check(charm)
-                _logger.debug(
-                    "new status for unit '%s' determined to be `%s`",
-                    charm.unit.name,  # type: ignore
-                    status,
-                )
-                charm.unit.status = status
-
-        return wrapper
-
-    return decorator
 
 
 def get_ingress_address(charm: ops.CharmBase, /, integration_name: str) -> str:
@@ -157,3 +79,116 @@ def get_ingress_address(charm: ops.CharmBase, /, integration_name: str) -> str:
     raise IngressAddressNotFoundError(
         f"ingress address for integration '{integration_name}' was not found"
     )
+
+
+def leader(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Only run method if the unit is the application leader, otherwise skip."""
+
+    @wraps(func)
+    def wrapper(charm: ops.CharmBase, *args: Any, **kwargs: Any) -> Any:
+        if not charm.unit.is_leader():
+            _logger.debug(
+                (
+                    "unit '%s' is not the leader of the '%s' application, ",
+                    "skipping run of method `%s.%s`",
+                ),
+                charm.unit.name,
+                charm.app.name,
+                charm.__class__.__name__,
+                func.__name__,
+            )
+            return None
+
+        _logger.debug(
+            "unit '%s' is the leader of the '%s' application, running method `%s.%s`",
+            charm.unit.name,
+            charm.app.name,
+            charm.__class__.__name__,
+            func.__name__,
+        )
+        return func(charm, *args, **kwargs)
+
+    return wrapper
+
+
+def reconfigure[T: ops.CharmBase](hook: Callable[[T], None] | None = None) -> Callable:
+    """Reconfigure a service after running an event handler.
+
+    Args:
+        hook: Reconfiguration hook to call after event handler completes.
+    """
+
+    def decorator(func: Callable[..., None]) -> Callable:
+        @wraps(func)
+        def wrapper(charm: T, *args: ops.EventBase, **kwargs: Any) -> None:
+            event, *_ = args
+
+            try:
+                func(charm, *args, **kwargs)
+                if hook is not None:
+                    hook(charm)
+            except StopCharm as e:
+                _logger.debug(
+                    (
+                        "`StopCharm` exception raised while running `%s` event handler `%s.%s` ",
+                        "on unit '%s'. aborting service reconfiguration `%s`",
+                    ),
+                    event.__class__.__name__,
+                    charm.__class__.__name__,
+                    func.__name__,
+                    charm.unit.name,  # type: ignore
+                    e.status,
+                )
+                raise
+
+        return wrapper
+
+    return decorator
+
+
+def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None) -> Callable:
+    """Refresh a charm's status after running an event handler.
+
+    Args:
+        hook: State check hook to call after event handler completes.
+    """
+
+    def decorator(func: Callable[..., None]) -> Callable:
+        @wraps(func)
+        def wrapper(charm: T, *args: ops.EventBase, **kwargs: Any) -> None:
+            event, *_ = args
+
+            try:
+                func(charm, *args, **kwargs)
+            except StopCharm as e:
+                _logger.debug(
+                    (
+                        "`StopCharm` exception raised while running `%s` event handler `%s.%s` ",
+                        "on unit '%s'. setting status to `%s`",
+                    ),
+                    event.__class__.__name__,
+                    charm.__class__.__name__,
+                    func.__name__,
+                    charm.unit.name,  # type: ignore
+                    e.status,
+                )
+                charm.unit.status = e.status
+                return
+
+            if hook is not None:
+                _logger.debug(
+                    "running status check function `%s` to determine new status for unit '%s'",
+                    hook.__name__,
+                    charm.unit.name,  # type: ignore
+                )
+                status = hook(charm)
+                _logger.debug(
+                    "new status for unit '%s' determined to be `%s`",
+                    charm.unit.name,  # type: ignore
+                    status,
+                )
+                charm.unit.status = status
+
+        return wrapper
+
+    return decorator

--- a/tests/unit/interfaces/sackd/test_sackd.py
+++ b/tests/unit/interfaces/sackd/test_sackd.py
@@ -28,8 +28,8 @@ from hpc_libs.interfaces import (
     SackdRequirer,
     SlurmctldDisconnectedEvent,
     SlurmctldReadyEvent,
-    controller_not_ready,
-    wait_when,
+    controller_ready,
+    wait_unless,
 )
 from hpc_libs.utils import refresh
 
@@ -51,8 +51,8 @@ class MockSackdProviderCharm(ops.CharmBase):
             self._on_slurmctld_ready,
         )
 
-    @refresh(check=None)
-    @wait_when(controller_not_ready)
+    @refresh(hook=None)
+    @wait_unless(controller_ready)
     def _on_slurmctld_ready(self, event: SlurmctldReadyEvent) -> None:
         data = self.slurmctld.get_controller_data(integration_id=event.relation.id)
         # Assume `remote_app_data` contains `auth_key` and `controllers` list.

--- a/tests/unit/interfaces/slurmd/test_slurmd.py
+++ b/tests/unit/interfaces/slurmd/test_slurmd.py
@@ -248,7 +248,12 @@ class TestSlurmdInterface:
                 "nhc_args": json.dumps(EXAMPLE_NHC_ARGS),
             }
             if ready
-            else {"controllers": json.dumps(EXAMPLE_CONTROLLERS)},
+            else {
+                "auth_key": '"***"',
+                "auth_key_id": json.dumps(auth_key_secret.id),
+                "controllers": json.dumps([]),
+                "nhc_args": json.dumps(EXAMPLE_NHC_ARGS),
+            },
         )
 
         state = provider_ctx.run(

--- a/tests/unit/interfaces/slurmd/test_slurmd.py
+++ b/tests/unit/interfaces/slurmd/test_slurmd.py
@@ -31,9 +31,9 @@ from hpc_libs.interfaces import (
     SlurmdProvider,
     SlurmdReadyEvent,
     SlurmdRequirer,
-    controller_not_ready,
-    partition_not_ready,
-    wait_when,
+    controller_ready,
+    partition_ready,
+    wait_unless,
 )
 from hpc_libs.utils import refresh
 
@@ -78,8 +78,8 @@ class MockSlurmdProviderCharm(ops.CharmBase):
             integration_id=event.relation.id,
         )
 
-    @refresh(check=None)
-    @wait_when(controller_not_ready)
+    @refresh(hook=None)
+    @wait_unless(controller_ready)
     def _on_slurmctld_ready(self, event: SlurmctldReadyEvent) -> None:
         data = self.slurmctld.get_controller_data(integration_id=event.relation.id)
         # Assume `remote_app_data` contains and `auth_key` and `controllers` list.
@@ -105,8 +105,8 @@ class MockSlurmdRequirerCharm(ops.CharmBase):
             self._on_slurmd_disconnected,
         )
 
-    @refresh(check=None)
-    @wait_when(partition_not_ready)
+    @refresh(hook=None)
+    @wait_unless(partition_ready)
     def _on_slurmd_ready(self, event: SlurmdReadyEvent) -> None:
         data = self.slurmd.get_compute_data(integration_id=event.relation.id)
         # Assume `remote_app_data` contains partition configuration data.

--- a/tests/unit/interfaces/slurmdbd/test_slurmdbd.py
+++ b/tests/unit/interfaces/slurmdbd/test_slurmdbd.py
@@ -32,9 +32,9 @@ from hpc_libs.interfaces import (
     SlurmdbdProvider,
     SlurmdbdReadyEvent,
     SlurmdbdRequirer,
-    controller_not_ready,
-    database_not_ready,
-    wait_when,
+    controller_ready,
+    database_ready,
+    wait_unless,
 )
 from hpc_libs.utils import refresh
 
@@ -71,8 +71,8 @@ class MockSlurmdbdProviderCharm(ops.CharmBase):
             integration_id=event.relation.id,
         )
 
-    @refresh(check=None)
-    @wait_when(controller_not_ready)
+    @refresh(hook=None)
+    @wait_unless(controller_ready)
     def _on_slurmctld_ready(self, event: SlurmctldReadyEvent) -> None:
         data = self.slurmctld.get_controller_data(integration_id=event.relation.id)
         # Assume `remote_app_data` contains `auth_key` and `jwt_key`.
@@ -109,8 +109,8 @@ class MockSlurmdbdRequirerCharm(ops.CharmBase):
             integration_id=event.relation.id,
         )
 
-    @refresh(check=None)
-    @wait_when(database_not_ready)
+    @refresh(hook=None)
+    @wait_unless(database_ready)
     def _on_slurmdbd_ready(self, event: SlurmdbdReadyEvent) -> None:
         data = self.slurmdbd.get_database_data(integration_id=event.relation.id)
         # Assume `remote_app_data` contains `hostname`.

--- a/tests/unit/interfaces/slurmrestd/test_slurmrestd.py
+++ b/tests/unit/interfaces/slurmrestd/test_slurmrestd.py
@@ -28,8 +28,8 @@ from hpc_libs.interfaces import (
     SlurmrestdConnectedEvent,
     SlurmrestdProvider,
     SlurmrestdRequirer,
-    controller_not_ready,
-    wait_when,
+    controller_ready,
+    wait_unless,
 )
 from hpc_libs.utils import refresh
 
@@ -57,8 +57,8 @@ class MockSlurmrestdProviderCharm(ops.CharmBase):
             self._on_slurmctld_ready,
         )
 
-    @refresh(check=None)
-    @wait_when(controller_not_ready)
+    @refresh(hook=None)
+    @wait_unless(controller_ready)
     def _on_slurmctld_ready(self, event: SlurmctldReadyEvent) -> None:
         data = self.slurmctld.get_controller_data(integration_id=event.relation.id)
         # Assume `remote_app_data` contains `auth_key` and `slurmconfig`.

--- a/tests/unit/utils/test_reconfigure.py
+++ b/tests/unit/utils/test_reconfigure.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the `reconfigure` utility."""
+
+import ops
+import pytest
+from ops import testing
+
+from hpc_libs.utils import StopCharm, reconfigure, refresh
+
+
+class MockCharm(ops.CharmBase):
+    """Mock charm for testing the `reconfigure` decorator."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        framework.observe(self.on.install, self._on_install)
+        framework.observe(self.on.start, self._on_start)
+        framework.observe(self.on.stop, self._on_stop)
+
+    @refresh(hook=None)
+    @reconfigure(hook=None)
+    def _on_install(self, _: ops.InstallEvent) -> None:
+        raise StopCharm(ops.BlockedStatus("no installation candidate"))
+
+    @refresh(hook=None)
+    @reconfigure(hook=None)
+    def _on_start(self, _: ops.StartEvent) -> None:
+        self.unit.status = ops.ActiveStatus()
+
+    @reconfigure(hook=lambda _: None)
+    def _on_stop(self, _: ops.StopEvent) -> None:
+        self.unit.status = ops.MaintenanceStatus("stopping unit")
+
+
+@pytest.fixture(scope="function")
+def mock_charm() -> testing.Context[MockCharm]:
+    return testing.Context(
+        MockCharm,
+        meta={
+            "name": "mock-reconfigure-charm",
+        },
+    )
+
+
+def test_reconfigure(mock_charm) -> None:
+    state = mock_charm.run(mock_charm.on.install(), testing.State())
+    assert state.unit_status == ops.BlockedStatus("no installation candidate")
+
+    state = mock_charm.run(mock_charm.on.start(), testing.State())
+    assert state.unit_status == ops.ActiveStatus()
+
+    state = mock_charm.run(mock_charm.on.stop(), testing.State())
+    assert state.unit_status == ops.MaintenanceStatus("stopping unit")

--- a/tests/unit/utils/test_refresh.py
+++ b/tests/unit/utils/test_refresh.py
@@ -21,7 +21,7 @@ from ops import testing
 from hpc_libs.utils import StopCharm, refresh
 
 refresh_no_check_func = refresh()
-refresh = refresh(check=lambda _: ops.ActiveStatus())
+refresh = refresh(hook=lambda _: ops.ActiveStatus())
 
 
 class MockCharm(ops.CharmBase):


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR introduces three major changes:

1. Inverts the `status_when` conditions to `status_unless`. This change was made to improve the readability of conditions for working with event handlers.
2. Adds a `reconfigure` utility that works similar to the `refresh` utility. This feature is being introduced as the `slurmctld`, `slurmd`, and `slurmdbd` operators all share common boilerplate for a `reconfigure` decorator to determine when charm configuration should be updated.
3. Adds a integration application data validation mechanism. This feature is being addressed to work around an edge case in the `slurmd` charm where NHC parameters arrived before the `controllers` or _slurm.key_ secret because `_on_config_changed` is called before `_on_slurmd_ready`.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This changes are motivated by @dsloanm's feedback on PR https://github.com/charmed-hpc/slurm-charms/pull/132


## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change.

