### PR TITLE
feat(interfaces/sackd): add app data validator

### DIFF
--- a/tests/unit/interfaces/sackd/test_sackd.py
+++ b/tests/unit/interfaces/sackd/test_sackd.py
@@ -142,7 +142,11 @@ class TestSackdInterface:
                 "controllers": json.dumps(EXAMPLE_CONTROLLERS),
             }
             if ready
-            else {"controllers": json.dumps(EXAMPLE_CONTROLLERS)},
+            else {
+                "auth_key": '"***"',
+                "auth_key_id": json.dumps(""),
+                "controllers": json.dumps([]),
+            },
         )
 
         state = provider_ctx.run(


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds an application data validator to the `sackd` interface to prevent race conditions where integration data arrives before the `controllers` field has been set to a valid `--conf-server` value.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to ongoing issues within the Slurm charms CI where the `sackd` service is failing to start.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change to fix a data race condition on smaller machines such as GitHub runners.