### PR TITLE
feat(interfaces): expose `load_secret` and `update_secret` as top-level functions

### DIFF
--- a/src/hpc_libs/interfaces/__init__.py
+++ b/src/hpc_libs/interfaces/__init__.py
@@ -18,9 +18,11 @@ __all__ = [
     # From `base.py`
     "Condition",
     "ConditionEvaluation",
+    "block_unless",
     "integration_exists",
     "integration_not_exists",
-    "block_unless",
+    "load_secret",
+    "update_secret",
     "wait_unless",
     # From `slurm/common.py`
     "ControllerData",
@@ -66,6 +68,8 @@ from .base import (
     block_unless,
     integration_exists,
     integration_not_exists,
+    load_secret,
+    update_secret,
     wait_unless,
 )
 from .slurm.common import (

--- a/src/hpc_libs/interfaces/base.py
+++ b/src/hpc_libs/interfaces/base.py
@@ -52,7 +52,7 @@ def update_secret(charm: ops.CharmBase, label: str, content: dict[str, str]) -> 
     try:
         secret = charm.model.get_secret(label=label)
         secret.set_content(content=content)
-    except ops.SecretNotFoundError:
+    except (ops.ModelError, ops.SecretNotFoundError):
         secret = charm.app.add_secret(label=label, content=content)
 
     return secret
@@ -67,7 +67,7 @@ def load_secret(charm: ops.CharmBase, label: str) -> ops.Secret | None:
     """
     try:
         return charm.model.get_secret(label=label)
-    except ops.SecretNotFoundError:
+    except (ops.ModelError, ops.SecretNotFoundError):
         return None
 
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR exposes the `load_secret` and `update_secret` functions as top-level functions - e.g. `from hpc_libs.interfaces import load_secret, update_secret` - so they can be used within our charms which managed their own secrets. This is helpful for cutting down on repetitive boilerplate within charms where access secrets directly.

Other changes:

- Updated `load_secret` to handle `ops.ModelError` when the model does not have access to the secret.
- Updated `update_secret` to handle `ops.ModelError` when the model does not have access to the secret.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to https://github.com/charmed-hpc/slurm-charms/pull/117

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change to a development dependency.