### PR TITLE
fix: ignore `relation-broken` when a unit is removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpc-libs"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.10"
 description = "Collection of utilities to manage HPC related services."
 authors = [

--- a/src/hpc_libs/interfaces/slurm/common.py
+++ b/src/hpc_libs/interfaces/slurm/common.py
@@ -170,6 +170,9 @@ class SlurmctldProvider(Interface):
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Revoke the departing application's access to Slurm secrets."""
+        if self.stored_state.unit_departing:
+            return
+
         if auth_secret := load_secret(
             self.charm,
             label=AUTH_KEY_TEMPLATE_LABEL.substitute(id=event.relation.id),
@@ -276,6 +279,9 @@ class SlurmctldRequirer(Interface):
 
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Handle when `slurmctld` is disconnected from an application."""
+        if self.stored_state.unit_departing:
+            return
+
         self.on.slurmctld_disconnected.emit(event.relation)
 
     def get_controller_data(self, integration_id: int | None = None) -> ControllerData:

--- a/src/hpc_libs/interfaces/slurm/oci_runtime.py
+++ b/src/hpc_libs/interfaces/slurm/oci_runtime.py
@@ -96,6 +96,9 @@ class OCIRuntimeProvider(SlurmctldRequirer):
 
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
+        if self.stored_state.unit_departing:
+            return
+
         super()._on_relation_broken(event)
 
     @leader
@@ -149,6 +152,9 @@ class OCIRuntimeRequirer(SlurmctldProvider):
 
     @leader
     def _on_relation_broken(self, event: OCIRuntimeDisconnectedEvent) -> None:
+        if self.stored_state.unit_departing:
+            return
+
         self.on.oci_runtime_disconnected.emit(event.relation)
 
     def get_oci_runtime_data(self, integration_id: int | None = None) -> OCIRuntimeData:

--- a/src/hpc_libs/interfaces/slurm/slurmd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmd.py
@@ -179,6 +179,9 @@ class SlurmdRequirer(SlurmctldProvider):
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Handle when a `slurmd` application is disconnected from `slurmctld`."""
+        if self.stored_state.unit_departing:
+            return
+
         super()._on_relation_broken(event)
         self.on.slurmd_disconnected.emit(event.relation)
 

--- a/src/hpc_libs/interfaces/slurm/slurmdbd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmdbd.py
@@ -105,6 +105,9 @@ class SlurmdbdProvider(SlurmctldRequirer):
 
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
+        if self.stored_state.unit_departing:
+            return
+
         super()._on_relation_broken(event)
 
     @leader
@@ -165,6 +168,9 @@ class SlurmdbdRequirer(SlurmctldProvider):
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Handle when a `slurmdbd` application is disconnected from `slurmctld`."""
+        if self.stored_state.unit_departing:
+            return
+
         super()._on_relation_broken(event)
         self.on.slurmdbd_disconnected.emit(event.relation)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "hpc-libs"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Prevents erroneous revocation of secrets and clearing of relation data when an application leader is removed during scale down.

# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR provides a fix for https://bugs.launchpad.net/juju/+bug/1979811.

Specifically, `relation-broken` events do not have enough information to determine whether they have been fired because the current unit is being removed, or because the integration itself is being removed. In the case where only the current unit is being removed, relation data should not be cleared nor secrets revoked. However, this is happening in the latest version of `hpc-libs`, resulting in application failure when a unit leader is removed during scale down.

As a workaround, `StoredState` is introduced to allow a flag to be set in the `relation-departed` hook if the current unit is being removed. The flag is then checked in the `relation-broken` event handler to determine whether data should be cleared or not.

`StoredState` is used rather than the unit databag to prevent extraneous `relation-changed` events from firing as the unit is being removed.

As an alternative, a `planned_units()` check in `relation-deparated` was considered, that would clear relation data when the last unit departed, but was discarded as scaling the application to 0 (without breaking the relation) then attempting to scale up would cause failure.

This fix is expected to be temporary as the introduction of `StoredState` is undesirable and the root issue may be resolved by Juju 4. The fix should be reassessed when the code is migrated in future.

This solution is inspired by:
https://github.com/canonical/postgresql-operator/blob/e13b871/src/relations/db.py#L193

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is necessary to support the merging of high-availability functionality for the `slurmctld` charm.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a bug fix with no user-facing changes.