### PR TITLE
fix: reduce scope of interface StoredState and reword comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpc-libs"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.10"
 description = "Collection of utilities to manage HPC related services."
 authors = [

--- a/src/hpc_libs/interfaces/base.py
+++ b/src/hpc_libs/interfaces/base.py
@@ -88,8 +88,7 @@ class Interface(ops.Object):
           a requirer/provider to successfully process a `RelationChangedEvent`.
     """
 
-    # A workaround for:
-    # https://bugs.launchpad.net/juju/+bug/1979811
+    # A workaround for: https://bugs.launchpad.net/juju/+bug/1979811
     #
     # `relation-broken` events do not have enough information to determine whether they have been
     # fired because the current unit is being removed, or because the integration itself is being

--- a/src/hpc_libs/interfaces/base.py
+++ b/src/hpc_libs/interfaces/base.py
@@ -88,7 +88,7 @@ class Interface(ops.Object):
           a requirer/provider to successfully process a `RelationChangedEvent`.
     """
 
-    # A temporary fix for:
+    # A workaround for:
     # https://bugs.launchpad.net/juju/+bug/1979811
     #
     # `relation-broken` events do not have enough information to determine whether they have been
@@ -105,7 +105,7 @@ class Interface(ops.Object):
     #
     # Inspired by:
     # https://github.com/canonical/postgresql-operator/blob/e13b871/src/relations/db.py#L193
-    stored_state = ops.StoredState()
+    _stored = ops.StoredState()
 
     def __init__(
         self,
@@ -124,7 +124,7 @@ class Interface(ops.Object):
         self._required_app_data = required_app_data if required_app_data else set()
         self._app_data_validator = app_data_validator if app_data_validator else lambda _: True
 
-        self.stored_state.set_default(unit_departing=False)
+        self._stored.set_default(unit_departing=False)
         self.framework.observe(
             self.charm.on[self._integration_name].relation_departed,
             self._on_relation_departed,
@@ -133,7 +133,7 @@ class Interface(ops.Object):
     def _on_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
         """Handle when a unit is departing from the relation."""
         if event.departing_unit == self.unit:
-            self.stored_state.unit_departing = True
+            self._stored.unit_departing = True
 
     @property
     def integrations(self) -> list[ops.Relation]:

--- a/src/hpc_libs/interfaces/slurm/common.py
+++ b/src/hpc_libs/interfaces/slurm/common.py
@@ -170,7 +170,7 @@ class SlurmctldProvider(Interface):
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Revoke the departing application's access to Slurm secrets."""
-        if self.stored_state.unit_departing:
+        if self._stored.unit_departing:
             return
 
         if auth_secret := load_secret(
@@ -279,7 +279,7 @@ class SlurmctldRequirer(Interface):
 
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Handle when `slurmctld` is disconnected from an application."""
-        if self.stored_state.unit_departing:
+        if self._stored.unit_departing:
             return
 
         self.on.slurmctld_disconnected.emit(event.relation)

--- a/src/hpc_libs/interfaces/slurm/oci_runtime.py
+++ b/src/hpc_libs/interfaces/slurm/oci_runtime.py
@@ -96,7 +96,7 @@ class OCIRuntimeProvider(SlurmctldRequirer):
 
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
-        if self.stored_state.unit_departing:
+        if self._stored.unit_departing:
             return
 
         super()._on_relation_broken(event)
@@ -152,7 +152,7 @@ class OCIRuntimeRequirer(SlurmctldProvider):
 
     @leader
     def _on_relation_broken(self, event: OCIRuntimeDisconnectedEvent) -> None:
-        if self.stored_state.unit_departing:
+        if self._stored.unit_departing:
             return
 
         self.on.oci_runtime_disconnected.emit(event.relation)

--- a/src/hpc_libs/interfaces/slurm/slurmd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmd.py
@@ -179,7 +179,7 @@ class SlurmdRequirer(SlurmctldProvider):
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Handle when a `slurmd` application is disconnected from `slurmctld`."""
-        if self.stored_state.unit_departing:
+        if self._stored.unit_departing:
             return
 
         super()._on_relation_broken(event)

--- a/src/hpc_libs/interfaces/slurm/slurmdbd.py
+++ b/src/hpc_libs/interfaces/slurm/slurmdbd.py
@@ -105,7 +105,7 @@ class SlurmdbdProvider(SlurmctldRequirer):
 
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
-        if self.stored_state.unit_departing:
+        if self._stored.unit_departing:
             return
 
         super()._on_relation_broken(event)
@@ -168,7 +168,7 @@ class SlurmdbdRequirer(SlurmctldProvider):
     @leader
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         """Handle when a `slurmdbd` application is disconnected from `slurmctld`."""
-        if self.stored_state.unit_departing:
+        if self._stored.unit_departing:
             return
 
         super()._on_relation_broken(event)


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Revisions to the new `StoredState` following input from @NucciTheBoss. The scope of the variable is reduced (`stored_state` -> `_stored`) and the comment calling the solution a "temporary fix" is reworded to "workaround", as this could be in place for longer than anticipated.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Necessary to polish the recent PR that introduced `StoredState`.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

No docs updates are needed as this is purely an internal change.