### PR TITLE
Allow setting the app status with StopCharm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charmed-hpc-libs"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.12"
 description = "Collection of utilities to manage HPC related services."
 authors = [

--- a/src/charmed_hpc_libs/ops/conditions.py
+++ b/src/charmed_hpc_libs/ops/conditions.py
@@ -48,12 +48,21 @@ type Condition[T: ops.CharmBase] = Callable[[T], ConditionEvaluation]
 
 
 class StopCharm(Exception):  # noqa N818
-    """Exception raised to set high-priority status message."""
+    """Exception raised to set high-priority status message.
 
-    @property
-    def status(self) -> ops.StatusBase:
-        """Get charm status passed as the first argument to this exception."""
-        return self.args[0]
+    Args:
+        status: The status to set on the unit (and optionally the application).
+        app_status: If ``True``, also set the application status to the unit
+            status when the unit is the leader.
+    """
+
+    def __init__(self, status: ops.StatusBase, *, set_app_status: bool = False) -> None:
+        super().__init__(status)  # only return the `status` message when using `str(e)`
+        self.status = status
+        self.set_app_status = set_app_status
+
+    def __repr__(self) -> str:  # noqa D105
+        return f"StopCharm({self.status!r}, set_app_status={self.set_app_status!r})"
 
 
 def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None) -> Callable:
@@ -74,7 +83,7 @@ def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None)
                 _logger.debug(
                     (
                         "`StopCharm` exception raised while running `%s` event handler `%s.%s` ",
-                        "on unit '%s'. setting status to `%s`",
+                        "on unit '%s'. setting unit status to `%s`",
                     ),
                     event.__class__.__name__,
                     charm.__class__.__name__,
@@ -83,6 +92,15 @@ def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None)
                     e.status,
                 )
                 charm.unit.status = e.status
+                if e.set_app_status:
+                    try:
+                        charm.app.status = e.status  # type: ignore
+                        _logger.debug(
+                            "setting app status to `%s`",
+                            e.status,
+                        )
+                    except RuntimeError:
+                        pass
                 return
 
             if hook is not None:

--- a/tests/unit/ops/test_conditions.py
+++ b/tests/unit/ops/test_conditions.py
@@ -20,6 +20,7 @@ from ops import testing
 
 from charmed_hpc_libs.ops import (
     ConditionEvaluation,
+    StopCharm,
     block_unless,
     integration_exists,
     integration_not_exists,
@@ -134,3 +135,45 @@ def test_refresh(mock_charm) -> None:
     )
 
     assert state.unit_status == ops.BlockedStatus("Waiting for integrations: [`metrics-server`]")
+
+
+class AppStatusCharm(ops.CharmBase):
+    """Mock charm for testing `StopCharm` app status propagation."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+        framework.observe(self.on.install, self._on_install)
+        framework.observe(self.on.start, self._on_start)
+
+    @refresh(hook=None)
+    def _on_install(self, _: ops.InstallEvent) -> None:
+        raise StopCharm(ops.BlockedStatus("blocked for app"), set_app_status=True)
+
+    @refresh(hook=None)
+    def _on_start(self, _: ops.StartEvent) -> None:
+        raise StopCharm(ops.BlockedStatus("blocked for unit only"))
+
+
+@pytest.fixture(scope="function")
+def app_status_charm() -> testing.Context[AppStatusCharm]:
+    return testing.Context(AppStatusCharm, meta={"name": "app-status-charm"})
+
+
+@pytest.mark.parametrize("is_leader", (True, False))
+def test_refresh_app_status(app_status_charm, is_leader) -> None:
+    """Test that `refresh` sets app status with `set_app_status=True` only when unit is leader."""
+    state = app_status_charm.run(
+        app_status_charm.on.install(), state=testing.State(leader=is_leader)
+    )
+    assert state.unit_status == ops.BlockedStatus("blocked for app")
+    if is_leader:
+        assert state.app_status == ops.BlockedStatus("blocked for app")
+    else:
+        assert state.app_status == ops.UnknownStatus()
+
+
+def test_refresh_no_app_status_by_default(app_status_charm) -> None:
+    """Test that `refresh` does not touch app status when `set_app_status` is `False` (default)."""
+    state = app_status_charm.run(app_status_charm.on.start(), state=testing.State(leader=True))
+    assert state.unit_status == ops.BlockedStatus("blocked for unit only")
+    assert state.app_status == ops.UnknownStatus()

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "charmed-hpc-libs"
-version = "0.1.3"
+version = "0.1.2"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "charmed-hpc-libs"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Adds a `app_status` field to `StopCharm` so that consumers can also set the app status if the current unit is the leader unit.

This is required in `filesystem_charms` such that we can reuse the `refresh` decorator there without having to create a separate handler.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

API docs for charmed-hpc-libs are not public.