### PR TITLE
feat: add `NodeExporterManager` and `exporters` module

### DIFF
--- a/src/charmed_hpc_libs/ops/__init__.py
+++ b/src/charmed_hpc_libs/ops/__init__.py
@@ -27,10 +27,15 @@ __all__ = [
     "wait_unless",
     # From `core` module
     "call",
+    "OperationsManager",
     "ServiceManager",
     # From `env.py`
     "EnvManager",
+    # From `exporters.py`
+    "NodeExporterManager",
     # From `machine` module
+    "SnapLifecycleManager",
+    "SnapOperationsManager",
     "SnapServiceManager",
     "SystemctlServiceManager",
     "is_container",
@@ -54,8 +59,17 @@ from .conditions import (
     refresh,
     wait_unless,
 )
-from .core import ServiceManager, call
+from .core import OperationsManager, ServiceManager, call
 from .env import EnvManager
-from .machine import SnapServiceManager, SystemctlServiceManager, is_container, snap, systemctl
+from .exporters import NodeExporterManager
+from .machine import (
+    SnapLifecycleManager,
+    SnapOperationsManager,
+    SnapServiceManager,
+    SystemctlServiceManager,
+    is_container,
+    snap,
+    systemctl,
+)
 from .network import get_ingress_address
 from .secrets import load_secret, update_secret

--- a/src/charmed_hpc_libs/ops/__init__.py
+++ b/src/charmed_hpc_libs/ops/__init__.py
@@ -27,15 +27,16 @@ __all__ = [
     "wait_unless",
     # From `core` module
     "call",
-    "OperationsManager",
+    "OpsManager",
     "ServiceManager",
     # From `env.py`
     "EnvManager",
     # From `exporters.py`
     "NodeExporterManager",
     # From `machine` module
+    "SnapConfigManager",
     "SnapLifecycleManager",
-    "SnapOperationsManager",
+    "SnapOpsManager",
     "SnapServiceManager",
     "SystemctlServiceManager",
     "is_container",
@@ -59,12 +60,13 @@ from .conditions import (
     refresh,
     wait_unless,
 )
-from .core import OperationsManager, ServiceManager, call
+from .core import OpsManager, ServiceManager, call
 from .env import EnvManager
 from .exporters import NodeExporterManager
 from .machine import (
+    SnapConfigManager,
     SnapLifecycleManager,
-    SnapOperationsManager,
+    SnapOpsManager,
     SnapServiceManager,
     SystemctlServiceManager,
     is_container,

--- a/src/charmed_hpc_libs/ops/core/__init__.py
+++ b/src/charmed_hpc_libs/ops/core/__init__.py
@@ -18,11 +18,11 @@ __all__ = [
     # From `call.py`
     "call",
     # From `operations.py`
-    "OperationsManager",
+    "OpsManager",
     # From `service.py`
     "ServiceManager",
 ]
 
 from .call import call
-from .operations import OperationsManager
+from .operations import OpsManager
 from .service import ServiceManager

--- a/src/charmed_hpc_libs/ops/core/__init__.py
+++ b/src/charmed_hpc_libs/ops/core/__init__.py
@@ -17,9 +17,12 @@
 __all__ = [
     # From `call.py`
     "call",
+    # From `operations.py`
+    "OperationsManager",
     # From `service.py`
     "ServiceManager",
 ]
 
 from .call import call
+from .operations import OperationsManager
 from .service import ServiceManager

--- a/src/charmed_hpc_libs/ops/core/operations.py
+++ b/src/charmed_hpc_libs/ops/core/operations.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base protocol for defining operations managers."""
+
+__all__ = ["OperationsManager"]
+
+from abc import abstractmethod
+from typing import Any, Protocol
+
+
+class OperationsManager(Protocol):  # pragma: no cover
+    """Base protocol for defining operation managers."""
+
+    @abstractmethod
+    def install(self, *args: Any, **kwargs: Any) -> None:  # noqa D102
+        raise NotImplementedError
+
+    @abstractmethod
+    def remove(self, *args: Any, **kwargs: Any) -> None:  # noqa D102
+        raise NotImplementedError

--- a/src/charmed_hpc_libs/ops/core/operations.py
+++ b/src/charmed_hpc_libs/ops/core/operations.py
@@ -14,19 +14,19 @@
 
 """Base protocol for defining operations managers."""
 
-__all__ = ["OperationsManager"]
+__all__ = ["OpsManager"]
 
 from abc import abstractmethod
-from typing import Any, Protocol
+from typing import Protocol
 
 
-class OperationsManager(Protocol):  # pragma: no cover
+class OpsManager(Protocol):  # pragma: no cover
     """Base protocol for defining operation managers."""
 
     @abstractmethod
-    def install(self, *args: Any, **kwargs: Any) -> None:  # noqa D102
+    def install(self) -> None:  # noqa D102
         raise NotImplementedError
 
     @abstractmethod
-    def remove(self, *args: Any, **kwargs: Any) -> None:  # noqa D102
+    def remove(self) -> None:  # noqa D102
         raise NotImplementedError

--- a/src/charmed_hpc_libs/ops/exporters.py
+++ b/src/charmed_hpc_libs/ops/exporters.py
@@ -38,7 +38,7 @@ class NodeExporterManager(SnapLifecycleManager):
             >>> ["ntp"]
         """
         try:
-            return self.get("collectors").split()
+            return self.config.get("collectors").split()
         except SnapError:
             # `SnapError` is raised if `collectors` option is empty.
             return []
@@ -54,9 +54,9 @@ class NodeExporterManager(SnapLifecycleManager):
             - The service will restart after the list of collectors is updated.
         """
         if len(value) == 0:
-            self.unset("collectors")
+            self.config.unset("collectors")
         else:
-            self.set({"collectors": " ".join(value)})
+            self.config.set({"collectors": " ".join(value)})
 
     def get_no_collectors(self) -> list[str]:
         """Get the list of disabled collectors.
@@ -68,7 +68,7 @@ class NodeExporterManager(SnapLifecycleManager):
             >>> ["mdadm", "netstat"]
         """
         try:
-            return self.get("no-collectors").split()
+            return self.config.get("no-collectors").split()
         except SnapError:
             # `SnapError` is raised if `no-collectors` option is empty.
             return []
@@ -84,9 +84,9 @@ class NodeExporterManager(SnapLifecycleManager):
             - The service will restart after the list of disabled collectors is updated.
         """
         if len(value) == 0:
-            self.unset("no-collectors")
+            self.config.unset("no-collectors")
         else:
-            self.set({"no-collectors": " ".join(value)})
+            self.config.set({"no-collectors": " ".join(value)})
 
     def get_web_listen_address(self) -> str:
         """Get web address and port used by the `node-exporter` service.
@@ -100,7 +100,7 @@ class NodeExporterManager(SnapLifecycleManager):
             >>> "127.0.0.1:9200"
         """
         try:
-            return self.get("web.listen-address")
+            return self.config.get("web.listen-address")
         except SnapError:
             # `SnapError` is raised if `web.listen-address` option is empty.
             return ""
@@ -116,6 +116,6 @@ class NodeExporterManager(SnapLifecycleManager):
             - The service will restart after the web listen address is updated.
         """
         if value:
-            self.set({"web.listen-address": value})
+            self.config.set({"web.listen-address": value})
         else:
-            self.unset("web.listen-address")
+            self.config.unset("web.listen-address")

--- a/src/charmed_hpc_libs/ops/exporters.py
+++ b/src/charmed_hpc_libs/ops/exporters.py
@@ -28,16 +28,13 @@ class NodeExporterManager(SnapLifecycleManager):
     def __init__(self) -> None:
         super().__init__("node-exporter")
 
-    @property
-    def collectors(self) -> list[str]:
+    def get_collectors(self) -> list[str]:
         """Get the list of optionally-enabled collectors.
-
-        Providing an empty list `[]` will disable all optionally-enabled collectors.
 
         Examples:
             >>> node_exporter = NodeExporterManager()
-            >>> node_exporter.collectors = ["ntp"]
-            >>> node_exporter.collectors
+            >>> node_exporter.set_collectors(["ntp"])
+            >>> node_exporter.get_collectors()
             >>> ["ntp"]
         """
         try:
@@ -46,21 +43,28 @@ class NodeExporterManager(SnapLifecycleManager):
             # `SnapError` is raised if `collectors` option is empty.
             return []
 
-    @collectors.setter
-    def collectors(self, value: Collection[str]) -> None:
+    def set_collectors(self, value: Collection[str]) -> None:
+        """Enable optional collectors.
+
+        Args:
+            value: Collection of optional collectors to enable.
+
+        Notes:
+            - Providing an empty collection will unset all optionally-enabled collectors.
+            - The service will restart after the list of collectors is updated.
+        """
         if len(value) == 0:
             self.unset("collectors")
         else:
             self.set({"collectors": " ".join(value)})
 
-    @property
-    def no_collectors(self) -> list[str]:
+    def get_no_collectors(self) -> list[str]:
         """Get the list of disabled collectors.
 
         Examples:
             >>> node_exporter = NodeExporterManager()
-            >>> node_exporter.no_collectors = ["mdadm", "netstat"]
-            >>> node_exporter.no_collectors
+            >>> node_exporter.set_no_collectors(["mdadm", "netstat"])
+            >>> node_exporter.get_no_collectors()
             >>> ["mdadm", "netstat"]
         """
         try:
@@ -69,23 +73,30 @@ class NodeExporterManager(SnapLifecycleManager):
             # `SnapError` is raised if `no-collectors` option is empty.
             return []
 
-    @no_collectors.setter
-    def no_collectors(self, value: Collection[str]) -> None:
+    def set_no_collectors(self, value: Collection[str]) -> None:
+        """Disable collectors.
+
+        Args:
+            value: Collection of collectors to disable.
+
+        Notes:
+            - Providing an empty collection will unset all disabled collectors.
+            - The service will restart after the list of disabled collectors is updated.
+        """
         if len(value) == 0:
             self.unset("no-collectors")
         else:
             self.set({"no-collectors": " ".join(value)})
 
-    @property
-    def web_listen_address(self) -> str:
+    def get_web_listen_address(self) -> str:
         """Get web address and port used by the `node-exporter` service.
 
         Examples:
             >>> node_exporter = NodeExporterManager()
-            >>> node_exporter.web_listen_address
+            >>> node_exporter.get_web_listen_address()
             >>> ":9200"
-            >>> node_exporter.web_listen_address = "127.0.0.1:9200"
-            >>> node_exporter.web_listen_address
+            >>> node_exporter.set_web_listen_address("127.0.0.1:9200")
+            >>> node_exporter.get_web_listen_address()
             >>> "127.0.0.1:9200"
         """
         try:
@@ -94,10 +105,17 @@ class NodeExporterManager(SnapLifecycleManager):
             # `SnapError` is raised if `web.listen-address` option is empty.
             return ""
 
-    @web_listen_address.setter
-    def web_listen_address(self, value: str) -> None:
-        self.set({"web.listen-address": value})
+    def set_web_listen_address(self, value: str) -> None:
+        """Set web address and port used by the `node-exporter` service.
 
-    @web_listen_address.deleter
-    def web_listen_address(self) -> None:
-        self.unset("web.listen-address")
+        Args:
+            value: The web listen address to use for the `node-exporter` service.
+
+        Notes:
+            - Providing an empty string will unset the web listen address.
+            - The service will restart after the web listen address is updated.
+        """
+        if value:
+            self.set({"web.listen-address": value})
+        else:
+            self.unset("web.listen-address")

--- a/src/charmed_hpc_libs/ops/exporters.py
+++ b/src/charmed_hpc_libs/ops/exporters.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manage metrics exporters in HPC charms."""
+
+__all__ = ["NodeExporterManager"]
+
+from collections.abc import Collection
+
+from ..errors import SnapError
+from .machine import SnapLifecycleManager
+
+
+class NodeExporterManager(SnapLifecycleManager):
+    """Manage the `node-exporter` metrics service."""
+
+    def __init__(self) -> None:
+        super().__init__("node-exporter")
+
+    @property
+    def collectors(self) -> list[str]:
+        """Get the list of optionally-enabled collectors.
+
+        Providing an empty list `[]` will disable all optionally-enabled collectors.
+
+        Examples:
+            >>> node_exporter = NodeExporterManager()
+            >>> node_exporter.collectors = ["ntp"]
+            >>> node_exporter.collectors
+            >>> ["ntp"]
+        """
+        try:
+            return self.get("collectors").split()
+        except SnapError:
+            # `SnapError` is raised if `collectors` option is empty.
+            return []
+
+    @collectors.setter
+    def collectors(self, value: Collection[str]) -> None:
+        if len(value) == 0:
+            self.unset("collectors")
+        else:
+            self.set({"collectors": " ".join(value)})
+
+    @property
+    def no_collectors(self) -> list[str]:
+        """Get the list of disabled collectors.
+
+        Examples:
+            >>> node_exporter = NodeExporterManager()
+            >>> node_exporter.no_collectors = ["mdadm", "netstat"]
+            >>> node_exporter.no_collectors
+            >>> ["mdadm", "netstat"]
+        """
+        try:
+            return self.get("no-collectors").split()
+        except SnapError:
+            # `SnapError` is raised if `no-collectors` option is empty.
+            return []
+
+    @no_collectors.setter
+    def no_collectors(self, value: Collection[str]) -> None:
+        if len(value) == 0:
+            self.unset("no-collectors")
+        else:
+            self.set({"no-collectors": " ".join(value)})
+
+    @property
+    def web_listen_address(self) -> str:
+        """Get web address and port used by the `node-exporter` service.
+
+        Examples:
+            >>> node_exporter = NodeExporterManager()
+            >>> node_exporter.web_listen_address
+            >>> ":9200"
+            >>> node_exporter.web_listen_address = "127.0.0.1:9200"
+            >>> node_exporter.web_listen_address
+            >>> "127.0.0.1:9200"
+        """
+        try:
+            return self.get("web.listen-address")
+        except SnapError:
+            # `SnapError` is raised if `web.listen-address` option is empty.
+            return ""
+
+    @web_listen_address.setter
+    def web_listen_address(self, value: str) -> None:
+        self.set({"web.listen-address": value})
+
+    @web_listen_address.deleter
+    def web_listen_address(self) -> None:
+        self.unset("web.listen-address")

--- a/src/charmed_hpc_libs/ops/machine/__init__.py
+++ b/src/charmed_hpc_libs/ops/machine/__init__.py
@@ -16,6 +16,8 @@
 
 __all__ = [
     # From `snap.py`
+    "SnapLifecycleManager",
+    "SnapOperationsManager",
     "SnapServiceManager",
     "snap",
     # From `systemd.py`
@@ -24,5 +26,5 @@ __all__ = [
     "is_container",
 ]
 
-from .snap import SnapServiceManager, snap
+from .snap import SnapLifecycleManager, SnapOperationsManager, SnapServiceManager, snap
 from .systemd import SystemctlServiceManager, is_container, systemctl

--- a/src/charmed_hpc_libs/ops/machine/__init__.py
+++ b/src/charmed_hpc_libs/ops/machine/__init__.py
@@ -16,8 +16,9 @@
 
 __all__ = [
     # From `snap.py`
+    "SnapConfigManager",
     "SnapLifecycleManager",
-    "SnapOperationsManager",
+    "SnapOpsManager",
     "SnapServiceManager",
     "snap",
     # From `systemd.py`
@@ -26,5 +27,5 @@ __all__ = [
     "is_container",
 ]
 
-from .snap import SnapLifecycleManager, SnapOperationsManager, SnapServiceManager, snap
+from .snap import SnapConfigManager, SnapLifecycleManager, SnapOpsManager, SnapServiceManager, snap
 from .systemd import SystemctlServiceManager, is_container, systemctl

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -83,8 +83,10 @@ class SnapOperationsManager(OperationsManager):
         command = ["connect", f"{self._snap}:{plug}"]
         if service and slot:
             command.append(f"{service}:{slot}")
+        elif service:
+            command.append(service)
         elif slot:
-            command.append(slot)
+            command.append(f":{slot}")
 
         snap(*command)
 

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -56,15 +56,11 @@ def snap(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
     return result.stdout, result.returncode
 
 
-class _SnapManager:
-    """Manage snap packages."""
+class SnapConfigManager:
+    """Control the configuration of a snap package."""
 
     def __init__(self, snap: str) -> None:
         self._snap = snap
-
-
-class SnapConfigManager(_SnapManager):
-    """Control the configuration of a snap package."""
 
     def get(self, key: str) -> Any:
         """Get snap configuration.
@@ -107,8 +103,11 @@ class SnapConfigManager(_SnapManager):
         snap("unset", self._snap, *keys)
 
 
-class SnapOpsManager(_SnapManager, OpsManager):
+class SnapOpsManager(OpsManager):
     """Control the operations of a `snap` package."""
+
+    def __init__(self, snap: str) -> None:
+        self._snap = snap
 
     def install(self) -> None:
         """Install package."""
@@ -145,7 +144,7 @@ class SnapOpsManager(_SnapManager, OpsManager):
         snap(*command)
 
 
-class SnapServiceManager(_SnapManager, ServiceManager):
+class SnapServiceManager(ServiceManager):
     """Control a service using `snap`.
 
     Args:
@@ -161,7 +160,7 @@ class SnapServiceManager(_SnapManager, ServiceManager):
     """
 
     def __init__(self, service: str, /, snap: str | None = None) -> None:
-        super().__init__(snap if snap else service)
+        self._snap = snap if snap else service
         self._service = f"{snap}.{service}" if snap else service
 
     def start(self) -> None:

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -37,7 +37,7 @@ def snap(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
             exits with a non-zero exit code.
 
     Raises:
-        SystemdError: Raised if a `snap` command fails and check is set to `True`.
+        SnapError: Raised if a `snap` command fails and check is set to `True`.
     """
     try:
         result = call("snap", *args, **kwargs)

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -14,15 +14,17 @@
 
 """Control `snap`/`snapd` in HPC machine charms."""
 
-__all__ = ["SnapServiceManager", "snap"]
+__all__ = ["SnapLifecycleManager", "SnapOperationsManager", "SnapServiceManager", "snap"]
 
+import json
+from collections.abc import Mapping
 from subprocess import CalledProcessError
 from typing import Any
 
 import yaml
 
 from ...errors import SnapError
-from ..core import ServiceManager, call
+from ..core import OperationsManager, ServiceManager, call
 
 
 def snap(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
@@ -46,6 +48,85 @@ def snap(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
         )
 
     return result.stdout, result.returncode
+
+
+class SnapOperationsManager(OperationsManager):
+    """Control the operations of a `snap` package."""
+
+    def __init__(self, snap: str) -> None:
+        self._snap = snap
+
+    def install(self) -> None:
+        """Install package."""
+        snap("install", self._snap)
+
+    def remove(self, /, purge: bool = False) -> None:
+        """Remove package.
+
+        Args:
+            purge: Remove the package without saving a snapshot of its data. Default: False.
+        """
+        command = ["remove", self._snap]
+        if purge:
+            command.append("--purge")
+
+        snap(*command)
+
+    def connect(self, plug: str, *, service: str | None = None, slot: str | None = None) -> None:
+        """Connect a plug to a slot.
+
+        Args:
+            plug: The plug to connect.
+            service: The snap service name to plug into.
+            slot: The snap service slot to plug in to.
+        """
+        command = ["connect", f"{self._snap}:{plug}"]
+        if service and slot:
+            command.append(f"{service}:{slot}")
+        elif slot:
+            command.append(slot)
+
+        snap(*command)
+
+    def get(self, key: str) -> Any:
+        """Get snap configuration.
+
+        Args:
+            key: Snap configuration key to get the value of.
+
+        Examples:
+            >>> package = SnapOperationsManager("slurm")
+            >>> package.get("exporter.port")
+            >>> 9100
+        """
+        result = snap("get", "-d", self._snap, key)
+        try:
+            data = json.loads(result[0])
+        except json.JSONDecodeError as e:
+            raise SnapError(
+                f"Failed to decode value of configuration option '{key}' for snap '{self._snap}'"
+            ) from e
+
+        return data[key]
+
+    def set(self, config: Mapping[str, Any]) -> None:
+        """Set snap configuration.
+
+        Args:
+            config: Snap configuration to set.
+
+        Notes:
+            - Keys can use dot notation.
+        """
+        snap("set", self._snap, *[f"{k}={json.dumps(v)}" for k, v in config.items()])
+
+    def unset(self, *keys: str) -> None:
+        """Unset snap configuration.
+
+        Args:
+            keys: Snap configuration keys to unset.
+        """
+        snap("unset", self._snap, *keys)
 
 
 class SnapServiceManager(ServiceManager):
@@ -99,3 +180,12 @@ class SnapServiceManager(ServiceManager):
         # Do not check for "active" in the service's state because the
         # word "active" is also part of "inactive".
         return "inactive" not in services[self._service]
+
+
+class SnapLifecycleManager(SnapOperationsManager, SnapServiceManager):
+    """Manage the full lifecycle operations of a snapped application."""
+
+    def __init__(self, snap: str, /, service: str = "") -> None:
+        # Call `__init__` explicitly to avoid opaque MRO resolution order.
+        SnapOperationsManager.__init__(self, snap)
+        SnapServiceManager.__init__(self, service or snap, snap=snap if service else None)

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -14,7 +14,13 @@
 
 """Control `snap`/`snapd` in HPC machine charms."""
 
-__all__ = ["SnapLifecycleManager", "SnapOperationsManager", "SnapServiceManager", "snap"]
+__all__ = [
+    "SnapConfigManager",
+    "SnapLifecycleManager",
+    "SnapOpsManager",
+    "SnapServiceManager",
+    "snap",
+]
 
 import json
 from collections.abc import Mapping
@@ -24,7 +30,7 @@ from typing import Any
 import yaml
 
 from ...errors import SnapError
-from ..core import OperationsManager, ServiceManager, call
+from ..core import OpsManager, ServiceManager, call
 
 
 def snap(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
@@ -50,45 +56,15 @@ def snap(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
     return result.stdout, result.returncode
 
 
-class SnapOperationsManager(OperationsManager):
-    """Control the operations of a `snap` package."""
+class _SnapManager:
+    """Manage snap packages."""
 
     def __init__(self, snap: str) -> None:
         self._snap = snap
 
-    def install(self) -> None:
-        """Install package."""
-        snap("install", self._snap)
 
-    def remove(self, /, purge: bool = False) -> None:
-        """Remove package.
-
-        Args:
-            purge: Remove the package without saving a snapshot of its data. Default: False.
-        """
-        command = ["remove", self._snap]
-        if purge:
-            command.append("--purge")
-
-        snap(*command)
-
-    def connect(self, plug: str, *, service: str | None = None, slot: str | None = None) -> None:
-        """Connect a plug to a slot.
-
-        Args:
-            plug: The plug to connect.
-            service: The snap service name to plug into.
-            slot: The snap service slot to plug in to.
-        """
-        command = ["connect", f"{self._snap}:{plug}"]
-        if service and slot:
-            command.append(f"{service}:{slot}")
-        elif service:
-            command.append(service)
-        elif slot:
-            command.append(f":{slot}")
-
-        snap(*command)
+class SnapConfigManager(_SnapManager):
+    """Control the configuration of a snap package."""
 
     def get(self, key: str) -> Any:
         """Get snap configuration.
@@ -97,7 +73,7 @@ class SnapOperationsManager(OperationsManager):
             key: Snap configuration key to get the value of.
 
         Examples:
-            >>> package = SnapOperationsManager("slurm")
+            >>> package = SnapConfigManager("slurm")
             >>> package.get("exporter.port")
             >>> 9100
         """
@@ -131,7 +107,45 @@ class SnapOperationsManager(OperationsManager):
         snap("unset", self._snap, *keys)
 
 
-class SnapServiceManager(ServiceManager):
+class SnapOpsManager(_SnapManager, OpsManager):
+    """Control the operations of a `snap` package."""
+
+    def install(self) -> None:
+        """Install package."""
+        snap("install", self._snap)
+
+    def remove(self, *, purge: bool = False) -> None:
+        """Remove package.
+
+        Args:
+            purge: Remove the package without saving a snapshot of its data. Default: False.
+        """
+        command = ["remove", self._snap]
+        if purge:
+            command.append("--purge")
+
+        snap(*command)
+
+    def connect(self, plug: str, *, service: str | None = None, slot: str | None = None) -> None:
+        """Connect a plug to a slot.
+
+        Args:
+            plug: The plug to connect.
+            service: The snap service name to plug into.
+            slot: The snap service slot to plug in to.
+        """
+        command = ["connect", f"{self._snap}:{plug}"]
+        if service and slot:
+            command.append(f"{service}:{slot}")
+        elif service:
+            command.append(service)
+        elif slot:
+            command.append(f":{slot}")
+
+        snap(*command)
+
+
+class SnapServiceManager(_SnapManager, ServiceManager):
     """Control a service using `snap`.
 
     Args:
@@ -147,8 +161,8 @@ class SnapServiceManager(ServiceManager):
     """
 
     def __init__(self, service: str, /, snap: str | None = None) -> None:
+        super().__init__(snap if snap else service)
         self._service = f"{snap}.{service}" if snap else service
-        self._snap = snap if snap else service
 
     def start(self) -> None:
         """Start service."""
@@ -184,10 +198,24 @@ class SnapServiceManager(ServiceManager):
         return "inactive" not in services[self._service]
 
 
-class SnapLifecycleManager(SnapOperationsManager, SnapServiceManager):
+class SnapLifecycleManager:
     """Manage the full lifecycle operations of a snapped application."""
 
     def __init__(self, snap: str, /, service: str = "") -> None:
-        # Call `__init__` explicitly to avoid opaque MRO resolution order.
-        SnapOperationsManager.__init__(self, snap)
-        SnapServiceManager.__init__(self, service or snap, snap=snap if service else None)
+        self._config_manager = SnapConfigManager(snap)
+        self._ops_manager = SnapOpsManager(snap)
+        self._service_manager = SnapServiceManager(service or snap, snap=snap if service else None)
+
+        self.install = self._ops_manager.install
+        self.remove = self._ops_manager.remove
+        self.connect = self._ops_manager.connect
+
+    @property
+    def config(self) -> SnapConfigManager:
+        """Manage the snap configuration."""
+        return self._config_manager
+
+    @property
+    def service(self) -> SnapServiceManager:
+        """Manage the snapped service."""
+        return self._service_manager

--- a/tests/unit/ops/test_exporters.py
+++ b/tests/unit/ops/test_exporters.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `exporters` library."""
+
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from charmed_hpc_libs.errors import SnapError
+from charmed_hpc_libs.ops import NodeExporterManager
+
+
+@pytest.fixture(scope="function")
+def mock_snap(mocker: MockerFixture) -> Mock:
+    """Create a mocked `snap` function."""
+    return mocker.patch("charmed_hpc_libs.ops.machine.snap.snap")
+
+
+class TestNodeExporterManager:
+    """Test the `NodeExporterManager` class."""
+
+    @pytest.fixture
+    def node_exporter_manager(self) -> NodeExporterManager:
+        """Create a `NodeExporterManager` object."""
+        return NodeExporterManager()
+
+    def test_collectors(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `collectors` property."""
+        mock_snap.return_value = ('{"collectors": "ntp cpu"}', 0)
+        assert node_exporter_manager.collectors == ["ntp", "cpu"]
+
+        node_exporter_manager.collectors = ["ntp", "cpu"]
+        mock_snap.assert_called_with("set", "node-exporter", 'collectors="ntp cpu"')
+
+        node_exporter_manager.collectors = []
+        mock_snap.assert_called_with("unset", "node-exporter", "collectors")
+
+        mock_snap.side_effect = SnapError(
+            "error: snap 'node-exporter' has no 'collectors' configuration option"
+        )
+        assert node_exporter_manager.collectors == []
+
+    def test_no_collectors(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `no_collectors` property."""
+        mock_snap.return_value = ('{"no-collectors": "mdadm netstat"}', 0)
+        assert node_exporter_manager.no_collectors == ["mdadm", "netstat"]
+
+        node_exporter_manager.no_collectors = ["netstat", "btrfs"]
+        mock_snap.assert_called_with("set", "node-exporter", 'no-collectors="netstat btrfs"')
+
+        node_exporter_manager.no_collectors = []
+        mock_snap.assert_called_with("unset", "node-exporter", "no-collectors")
+
+        mock_snap.side_effect = SnapError(
+            "error: snap 'node-exporter' has no 'no-collectors' configuration option"
+        )
+        assert node_exporter_manager.no_collectors == []
+
+    def test_web_listen_address(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `web_listen_address` property."""
+        mock_snap.return_value = ('{"web.listen-address": "127.0.0.1:9200"}', 0)
+        assert node_exporter_manager.web_listen_address == "127.0.0.1:9200"
+
+        node_exporter_manager.web_listen_address = "127.0.0.1:9200"
+        mock_snap.assert_called_with("set", "node-exporter", 'web.listen-address="127.0.0.1:9200"')
+
+        del node_exporter_manager.web_listen_address
+        mock_snap.assert_called_with("unset", "node-exporter", "web.listen-address")
+
+        mock_snap.side_effect = SnapError(
+            "error: snap 'node-exporter' has no 'web.listen-address' configuration option"
+        )
+        assert node_exporter_manager.web_listen_address == ""

--- a/tests/unit/ops/test_exporters.py
+++ b/tests/unit/ops/test_exporters.py
@@ -37,50 +37,56 @@ class TestNodeExporterManager:
         """Create a `NodeExporterManager` object."""
         return NodeExporterManager()
 
-    def test_collectors(self, node_exporter_manager, mock_snap) -> None:
-        """Test the `collectors` property."""
+    def test_get_collectors(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `get_collectors` method."""
         mock_snap.return_value = ('{"collectors": "ntp cpu"}', 0)
-        assert node_exporter_manager.collectors == ["ntp", "cpu"]
-
-        node_exporter_manager.collectors = ["ntp", "cpu"]
-        mock_snap.assert_called_with("set", "node-exporter", 'collectors="ntp cpu"')
-
-        node_exporter_manager.collectors = []
-        mock_snap.assert_called_with("unset", "node-exporter", "collectors")
+        assert node_exporter_manager.get_collectors() == ["ntp", "cpu"]
 
         mock_snap.side_effect = SnapError(
             "error: snap 'node-exporter' has no 'collectors' configuration option"
         )
-        assert node_exporter_manager.collectors == []
+        assert node_exporter_manager.get_collectors() == []
 
-    def test_no_collectors(self, node_exporter_manager, mock_snap) -> None:
-        """Test the `no_collectors` property."""
+    def test_set_collectors(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `set_collectors` method."""
+        node_exporter_manager.set_collectors(["ntp", "cpu"])
+        mock_snap.assert_called_with("set", "node-exporter", 'collectors="ntp cpu"')
+
+        node_exporter_manager.set_collectors([])
+        mock_snap.assert_called_with("unset", "node-exporter", "collectors")
+
+    def test_get_no_collectors(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `get_no_collectors` method."""
         mock_snap.return_value = ('{"no-collectors": "mdadm netstat"}', 0)
-        assert node_exporter_manager.no_collectors == ["mdadm", "netstat"]
-
-        node_exporter_manager.no_collectors = ["netstat", "btrfs"]
-        mock_snap.assert_called_with("set", "node-exporter", 'no-collectors="netstat btrfs"')
-
-        node_exporter_manager.no_collectors = []
-        mock_snap.assert_called_with("unset", "node-exporter", "no-collectors")
+        assert node_exporter_manager.get_no_collectors() == ["mdadm", "netstat"]
 
         mock_snap.side_effect = SnapError(
             "error: snap 'node-exporter' has no 'no-collectors' configuration option"
         )
-        assert node_exporter_manager.no_collectors == []
+        assert node_exporter_manager.get_no_collectors() == []
 
-    def test_web_listen_address(self, node_exporter_manager, mock_snap) -> None:
-        """Test the `web_listen_address` property."""
+    def test_set_no_collectors(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `set_no_collectors` method."""
+        node_exporter_manager.set_no_collectors(["netstat", "btrfs"])
+        mock_snap.assert_called_with("set", "node-exporter", 'no-collectors="netstat btrfs"')
+
+        node_exporter_manager.set_no_collectors([])
+        mock_snap.assert_called_with("unset", "node-exporter", "no-collectors")
+
+    def test_get_web_listen_address(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `get_web_listen_address` method."""
         mock_snap.return_value = ('{"web.listen-address": "127.0.0.1:9200"}', 0)
-        assert node_exporter_manager.web_listen_address == "127.0.0.1:9200"
-
-        node_exporter_manager.web_listen_address = "127.0.0.1:9200"
-        mock_snap.assert_called_with("set", "node-exporter", 'web.listen-address="127.0.0.1:9200"')
-
-        del node_exporter_manager.web_listen_address
-        mock_snap.assert_called_with("unset", "node-exporter", "web.listen-address")
+        assert node_exporter_manager.get_web_listen_address() == "127.0.0.1:9200"
 
         mock_snap.side_effect = SnapError(
             "error: snap 'node-exporter' has no 'web.listen-address' configuration option"
         )
-        assert node_exporter_manager.web_listen_address == ""
+        assert node_exporter_manager.get_web_listen_address() == ""
+
+    def test_set_web_listen_address(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `set_web_listen_address` method."""
+        node_exporter_manager.set_web_listen_address("127.0.0.1:9200")
+        mock_snap.assert_called_with("set", "node-exporter", 'web.listen-address="127.0.0.1:9200"')
+
+        node_exporter_manager.set_web_listen_address("")
+        mock_snap.assert_called_with("unset", "node-exporter", "web.listen-address")

--- a/tests/unit/ops/test_snap.py
+++ b/tests/unit/ops/test_snap.py
@@ -133,10 +133,10 @@ class TestSnapOperationsManager:
         mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd:network-observe")
 
         operations_manager.connect("network-observe", slot="system")
-        mock_snap.assert_called_with("connect", "slurm:network-observe", "system")
+        mock_snap.assert_called_with("connect", "slurm:network-observe", ":system")
 
         operations_manager.connect("network-observe", service="snapd")
-        mock_snap.assert_called_with("connect", "slurm:network-observe")
+        mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd")
 
     def test_get(self, operations_manager, mock_snap) -> None:
         """Test the `get` method."""

--- a/tests/unit/ops/test_snap.py
+++ b/tests/unit/ops/test_snap.py
@@ -21,7 +21,13 @@ import pytest
 from pytest_mock import MockerFixture
 
 from charmed_hpc_libs.errors import SnapError
-from charmed_hpc_libs.ops import SnapOperationsManager, SnapServiceManager, snap
+from charmed_hpc_libs.ops import (
+    SnapConfigManager,
+    SnapLifecycleManager,
+    SnapOpsManager,
+    SnapServiceManager,
+    snap,
+)
 
 # This input is modified. If the service name is the same as the snap name, then the
 # service will be started as `snap start slurm` rather than `snap start slurm.slurm`.
@@ -103,70 +109,79 @@ def test_snap(mocker: MockerFixture) -> None:
     )
 
 
-class TestSnapOperationsManager:
-    """Test the `SnapOperationsManager` class."""
+class TestSnapConfigManager:
+    """Test the `SnapConfigManager` class."""
 
     @pytest.fixture
-    def operations_manager(self) -> SnapOperationsManager:
-        """Create a `SnapOperationsManager` object."""
-        return SnapOperationsManager("slurm")
+    def config_manager(self) -> SnapConfigManager:
+        """Create a `SnapConfigManager` object."""
+        return SnapConfigManager("slurm")
 
-    def test_install(self, operations_manager, mock_snap) -> None:
-        """Test the `install` method."""
-        operations_manager.install()
-        mock_snap.assert_called_with("install", "slurm")
-
-    def test_remove(self, operations_manager, mock_snap) -> None:
-        """Test the `remove` method."""
-        operations_manager.remove()
-        mock_snap.assert_called_with("remove", "slurm")
-
-        operations_manager.remove(purge=True)
-        mock_snap.assert_called_with("remove", "slurm", "--purge")
-
-    def test_connect(self, operations_manager, mock_snap) -> None:
-        """Test the `connect` method."""
-        operations_manager.connect("network-observe")
-        mock_snap.assert_called_with("connect", "slurm:network-observe")
-
-        operations_manager.connect("network-observe", service="snapd", slot="network-observe")
-        mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd:network-observe")
-
-        operations_manager.connect("network-observe", slot="system")
-        mock_snap.assert_called_with("connect", "slurm:network-observe", ":system")
-
-        operations_manager.connect("network-observe", service="snapd")
-        mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd")
-
-    def test_get(self, operations_manager, mock_snap) -> None:
+    def test_get(self, config_manager, mock_snap) -> None:
         """Test the `get` method."""
         mock_snap.return_value = ('{"exporter.port": 9100}', 0)
-        assert operations_manager.get("exporter.port") == 9100
+        assert config_manager.get("exporter.port") == 9100
         mock_snap.assert_called_with("get", "-d", "slurm", "exporter.port")
 
         mock_snap.return_value = ('{"key": "value"}', 0)
-        assert operations_manager.get("key") == "value"
+        assert config_manager.get("key") == "value"
 
         mock_snap.return_value = ("not valid json", 0)
         with pytest.raises(SnapError) as exec_info:
-            operations_manager.get("exporter.port")
+            config_manager.get("exporter.port")
         assert exec_info.value.message == (
             "Failed to decode value of configuration option 'exporter.port' for snap 'slurm'"
         )
 
         mock_snap.side_effect = SnapError("snap command failed")
         with pytest.raises(SnapError):
-            operations_manager.get("exporter.port")
+            config_manager.get("exporter.port")
 
-    def test_set(self, operations_manager, mock_snap) -> None:
+    def test_set(self, config_manager, mock_snap) -> None:
         """Test the `set` method."""
-        operations_manager.set({"port": "8817"})
+        config_manager.set({"port": "8817"})
         mock_snap.assert_called_with("set", "slurm", 'port="8817"')
 
-    def test_unset(self, operations_manager, mock_snap) -> None:
+    def test_unset(self, config_manager, mock_snap) -> None:
         """Test the `unset` method."""
-        operations_manager.unset("port")
+        config_manager.unset("port")
         mock_snap.assert_called_with("unset", "slurm", "port")
+
+
+class TestSnapOpsManager:
+    """Test the `SnapOpsManager` class."""
+
+    @pytest.fixture
+    def ops_manager(self) -> SnapOpsManager:
+        """Create a `SnapOpsManager` object."""
+        return SnapOpsManager("slurm")
+
+    def test_install(self, ops_manager, mock_snap) -> None:
+        """Test the `install` method."""
+        ops_manager.install()
+        mock_snap.assert_called_with("install", "slurm")
+
+    def test_remove(self, ops_manager, mock_snap) -> None:
+        """Test the `remove` method."""
+        ops_manager.remove()
+        mock_snap.assert_called_with("remove", "slurm")
+
+        ops_manager.remove(purge=True)
+        mock_snap.assert_called_with("remove", "slurm", "--purge")
+
+    def test_connect(self, ops_manager, mock_snap) -> None:
+        """Test the `connect` method."""
+        ops_manager.connect("network-observe")
+        mock_snap.assert_called_with("connect", "slurm:network-observe")
+
+        ops_manager.connect("network-observe", service="snapd", slot="network-observe")
+        mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd:network-observe")
+
+        ops_manager.connect("network-observe", slot="system")
+        mock_snap.assert_called_with("connect", "slurm:network-observe", ":system")
+
+        ops_manager.connect("network-observe", service="snapd")
+        mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd")
 
 
 @pytest.mark.parametrize(
@@ -264,3 +279,22 @@ class TestSnapServiceManager:
                 assert exec_info.value.message == (
                     "cannot retrieve 'slurm.slurmctld' service info with 'snap info slurm'"
                 )
+
+
+class TestSnapLifecycleManager:
+    """Test the `SnapLifecycleManager` class."""
+
+    @pytest.fixture
+    def lifecycle_manager(self) -> SnapLifecycleManager:
+        """Create a `SnapLifecycleManager` object."""
+        return SnapLifecycleManager("slurm")
+
+    def test_config(self, lifecycle_manager, mock_snap) -> None:
+        """Test the `config` property."""
+        mock_snap.return_value = ('{"exporter.port": 9100}', 0)
+        assert lifecycle_manager.config.get("exporter.port") == 9100
+
+    def test_service(self, lifecycle_manager, mock_snap) -> None:
+        """Test the `service` property."""
+        lifecycle_manager.service.start()
+        mock_snap.assert_called_with("start", "slurm")

--- a/tests/unit/ops/test_snap.py
+++ b/tests/unit/ops/test_snap.py
@@ -21,7 +21,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from charmed_hpc_libs.errors import SnapError
-from charmed_hpc_libs.ops import SnapServiceManager, snap
+from charmed_hpc_libs.ops import SnapOperationsManager, SnapServiceManager, snap
 
 # This input is modified. If the service name is the same as the snap name, then the
 # service will be started as `snap start slurm` rather than `snap start slurm.slurm`.
@@ -71,6 +71,12 @@ channels:
 """
 
 
+@pytest.fixture(scope="function")
+def mock_snap(mocker: MockerFixture) -> Mock:
+    """Create a mocked `snap` function."""
+    return mocker.patch("charmed_hpc_libs.ops.machine.snap.snap")
+
+
 def test_snap(mocker: MockerFixture) -> None:
     """Test the `snap` function."""
     mock_run = mocker.patch.object(subprocess, "run")
@@ -97,6 +103,72 @@ def test_snap(mocker: MockerFixture) -> None:
     )
 
 
+class TestSnapOperationsManager:
+    """Test the `SnapOperationsManager` class."""
+
+    @pytest.fixture
+    def operations_manager(self) -> SnapOperationsManager:
+        """Create a `SnapOperationsManager` object."""
+        return SnapOperationsManager("slurm")
+
+    def test_install(self, operations_manager, mock_snap) -> None:
+        """Test the `install` method."""
+        operations_manager.install()
+        mock_snap.assert_called_with("install", "slurm")
+
+    def test_remove(self, operations_manager, mock_snap) -> None:
+        """Test the `remove` method."""
+        operations_manager.remove()
+        mock_snap.assert_called_with("remove", "slurm")
+
+        operations_manager.remove(purge=True)
+        mock_snap.assert_called_with("remove", "slurm", "--purge")
+
+    def test_connect(self, operations_manager, mock_snap) -> None:
+        """Test the `connect` method."""
+        operations_manager.connect("network-observe")
+        mock_snap.assert_called_with("connect", "slurm:network-observe")
+
+        operations_manager.connect("network-observe", service="snapd", slot="network-observe")
+        mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd:network-observe")
+
+        operations_manager.connect("network-observe", slot="system")
+        mock_snap.assert_called_with("connect", "slurm:network-observe", "system")
+
+        operations_manager.connect("network-observe", service="snapd")
+        mock_snap.assert_called_with("connect", "slurm:network-observe")
+
+    def test_get(self, operations_manager, mock_snap) -> None:
+        """Test the `get` method."""
+        mock_snap.return_value = ('{"exporter.port": 9100}', 0)
+        assert operations_manager.get("exporter.port") == 9100
+        mock_snap.assert_called_with("get", "-d", "slurm", "exporter.port")
+
+        mock_snap.return_value = ('{"key": "value"}', 0)
+        assert operations_manager.get("key") == "value"
+
+        mock_snap.return_value = ("not valid json", 0)
+        with pytest.raises(SnapError) as exec_info:
+            operations_manager.get("exporter.port")
+        assert exec_info.value.message == (
+            "Failed to decode value of configuration option 'exporter.port' for snap 'slurm'"
+        )
+
+        mock_snap.side_effect = SnapError("snap command failed")
+        with pytest.raises(SnapError):
+            operations_manager.get("exporter.port")
+
+    def test_set(self, operations_manager, mock_snap) -> None:
+        """Test the `set` method."""
+        operations_manager.set({"port": "8817"})
+        mock_snap.assert_called_with("set", "slurm", 'port="8817"')
+
+    def test_unset(self, operations_manager, mock_snap) -> None:
+        """Test the `unset` method."""
+        operations_manager.unset("port")
+        mock_snap.assert_called_with("unset", "slurm", "port")
+
+
 @pytest.mark.parametrize(
     "service_name_is_snap_name",
     (
@@ -113,11 +185,6 @@ class TestSnapServiceManager:
         return SnapServiceManager(
             "slurmctld", snap="slurm" if not service_name_is_snap_name else None
         )
-
-    @pytest.fixture
-    def mock_snap(self, mocker: MockerFixture) -> Mock:
-        """Create a mocked `snap` function."""
-        return mocker.patch("charmed_hpc_libs.ops.machine.snap.snap")
 
     def test_start(self, service_manager, mock_snap, service_name_is_snap_name) -> None:
         """Test the `start` method."""


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR proposes adding a `NodeExporterManager` class that can be used to manage a [`node_exporter`](https://snapcraft.io/node-exporter) service on machine charms. This class can be used to enable exporting machine metrics without the OpenTelemetry Collector operator.

Key changes include:

1. Adding the protocol `OperationsManager`. This class is inspired from the `OpsManager` class in `slurm-ops`, but more generic.
2. Adding the `SnapOperationsManager` class. This class provides method for managing common operations around a snap package such as installation and removal, connecting plugs to different slots, and managing the packages; configuration.
3. Adding the `SnapLifecycleManager` class. This class inherits from both `SnapServiceManager` and `SnapOperationsManager`. This class is intended to be used for building classes that are intended to manage the entire lifecycle of an application, unlike `slurm-ops` where we use composition instead to create managers for more complicated services.
4. Adding the `NodeExporterManager` class. This class is used to manage a snap-based node exporter service on machine charms. It can be used in charms like `sackd` and `slurmd` to provide a node exporter endpoint but not require an OpenTelemetry Collector instance. 

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/charmed-hpc/hpc-libs/issues/127

### Other things to note

 I did a preliminary co-pilot review in my IDE (PyCharm).

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change.