### PR TITLE
feat(ops): add `DCGMManager` for exporting GPU metrics

### DIFF
--- a/src/charmed_hpc_libs/ops/__init__.py
+++ b/src/charmed_hpc_libs/ops/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     # From `exporters.py`
     "NodeExporterManager",
     # From `machine` module
+    "DCGMManager",
     "SnapConfigManager",
     "SnapLifecycleManager",
     "SnapOpsManager",
@@ -64,6 +65,7 @@ from .core import OpsManager, ServiceManager, call
 from .env import EnvManager
 from .exporters import NodeExporterManager
 from .machine import (
+    DCGMManager,
     SnapConfigManager,
     SnapLifecycleManager,
     SnapOpsManager,

--- a/src/charmed_hpc_libs/ops/core/operations.py
+++ b/src/charmed_hpc_libs/ops/core/operations.py
@@ -19,9 +19,15 @@ __all__ = ["OpsManager"]
 from abc import abstractmethod
 from typing import Protocol
 
+from .service import ServiceManager
+
 
 class OpsManager(Protocol):  # pragma: no cover
     """Base protocol for defining operation managers."""
+
+    @abstractmethod
+    def service_manager_for(self, service: str) -> ServiceManager:  # noqa D102
+        raise NotImplementedError
 
     @abstractmethod
     def install(self) -> None:  # noqa D102

--- a/src/charmed_hpc_libs/ops/exporters.py
+++ b/src/charmed_hpc_libs/ops/exporters.py
@@ -17,9 +17,10 @@
 __all__ = ["NodeExporterManager"]
 
 from collections.abc import Collection
+from functools import cached_property
 
 from ..errors import SnapError
-from .machine import SnapLifecycleManager
+from .machine import SnapLifecycleManager, SnapServiceManager
 
 
 class NodeExporterManager(SnapLifecycleManager):
@@ -27,6 +28,11 @@ class NodeExporterManager(SnapLifecycleManager):
 
     def __init__(self) -> None:
         super().__init__("node-exporter")
+
+    @cached_property
+    def service(self) -> SnapServiceManager:
+        """Get the service manager for the `node-exporter` service."""
+        return self._ops_manager.service_manager_for("node-exporter")
 
     def get_collectors(self) -> list[str]:
         """Get the list of optionally-enabled collectors.

--- a/src/charmed_hpc_libs/ops/machine/__init__.py
+++ b/src/charmed_hpc_libs/ops/machine/__init__.py
@@ -15,6 +15,8 @@
 """Libraries for interfacing with machine resources."""
 
 __all__ = [
+    # From `nvidia.py`
+    "DCGMManager",
     # From `snap.py`
     "SnapConfigManager",
     "SnapLifecycleManager",
@@ -27,5 +29,6 @@ __all__ = [
     "is_container",
 ]
 
+from .nvidia import DCGMManager
 from .snap import SnapConfigManager, SnapLifecycleManager, SnapOpsManager, SnapServiceManager, snap
 from .systemd import SystemctlServiceManager, is_container, systemctl

--- a/src/charmed_hpc_libs/ops/machine/nvidia.py
+++ b/src/charmed_hpc_libs/ops/machine/nvidia.py
@@ -67,20 +67,20 @@ class DCGMManager(SnapLifecycleManager):
         else:
             self.config.unset("dcgm-exporter-address")
 
-    def get_dcgm_exporter_metrics_file(self) -> Path:
+    def get_dcgm_exporter_metrics_file(self) -> Path | None:
         """Get the path to the custom CSV metrics file loaded by the `dcgm-exporter` service.
 
         Notes:
             - The default metrics file is located at
               `/snap/dcgm/current/etc/dcgm-exporter/default-counters.csv`
-            - An empty `Path` object is returned if the output of 'snap get -d dcgm' does not
+            - An `None` is returned if the output of 'snap get -d dcgm' does not
               contain a configured path for the metrics file.
         """
         try:
             return Path(self.config.get("dcgm-exporter-metrics-file"))
         except SnapError:
             # `SnapError` is raised if `dcgm-exporter-metrics-file` option is empty.
-            return Path()
+            return None
 
     def set_dcgm_exporter_metrics_file(self, value: str | Path) -> None:
         """Set the path to the custom CSV metrics file loaded by the `dcgm-exporter` service.
@@ -89,12 +89,12 @@ class DCGMManager(SnapLifecycleManager):
             value: The path to the new custom metrics file.
 
         Notes:
-            - Providing an empty string will unset the custom metrics file path.
+            - Providing an empty string or `Path` object will unset the custom metrics file path.
         """
-        if value:
-            self.config.set({"dcgm-exporter-metrics-file": str(value)})
-        else:
+        if value == "" or value == Path():
             self.config.unset("dcgm-exporter-metrics-file")
+        else:
+            self.config.set({"dcgm-exporter-metrics-file": str(value)})
 
     def get_nv_hostengine_port(self) -> int | None:
         """Get the port that the NV-Hostengine is listening on.

--- a/src/charmed_hpc_libs/ops/machine/nvidia.py
+++ b/src/charmed_hpc_libs/ops/machine/nvidia.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manage Nvidia GPU-related devices and artifacts."""
+
+__all__ = ["DCGMManager"]
+
+from functools import cached_property
+from pathlib import Path
+
+from ...errors import SnapError
+from .snap import SnapLifecycleManager, SnapServiceManager
+
+
+class DCGMManager(SnapLifecycleManager):
+    """Control the lifecycle of Nvidia's Data Center GPU Manager."""
+
+    def __init__(self) -> None:
+        super().__init__("dcgm")
+
+    @cached_property
+    def exporter(self) -> SnapServiceManager:
+        """Get the service manager for the `dcgm-exporter` service."""
+        return self._ops_manager.service_manager_for("dcgm-exporter")
+
+    @cached_property
+    def nv_hostengine(self) -> SnapServiceManager:
+        """Get the service manager for the `nv-hostengine` service."""
+        return self._ops_manager.service_manager_for("nv-hostengine")
+
+    def get_dcgm_exporter_address(self) -> str:
+        """Get the address used by the `dcgm-exporter` service.
+
+        Notes:
+            - The default address is `:9400`
+            - An empty `str` object is returned if the output 'snap get -d dcgm' does not
+              contain a configured address for the `dcgm-exporter` service.
+        """
+        try:
+            return self.config.get("dcgm-exporter-address")
+        except SnapError:
+            # `SnapError` is raised if `dcgm-exporter-address` option is empty.
+            return ""
+
+    def set_dcgm_exporter_address(self, value: str) -> None:
+        """Set the web address and port used by the `dcgm-exporter` service.
+
+        Args:
+            value: The address to use for the `dcgm-exporter` service.
+
+        Notes:
+            - Providing an empty string will unset the custom listen address.
+        """
+        if value:
+            self.config.set({"dcgm-exporter-address": str(value)})
+        else:
+            self.config.unset("dcgm-exporter-address")
+
+    def get_dcgm_exporter_metrics_file(self) -> Path:
+        """Get the path to the custom CSV metrics file loaded by the `dcgm-exporter` service.
+
+        Notes:
+            - The default metrics file is located at
+              `/snap/dcgm/current/etc/dcgm-exporter/default-counters.csv`
+            - An empty `Path` object is returned if the output of 'snap get -d dcgm' does not
+              contain a configured path for the metrics file.
+        """
+        try:
+            return Path(self.config.get("dcgm-exporter-metrics-file"))
+        except SnapError:
+            # `SnapError` is raised if `dcgm-exporter-metrics-file` option is empty.
+            return Path()
+
+    def set_dcgm_exporter_metrics_file(self, value: str | Path) -> None:
+        """Set the path to the custom CSV metrics file loaded by the `dcgm-exporter` service.
+
+        Args:
+            value: The path to the new custom metrics file.
+
+        Notes:
+            - Providing an empty string will unset the custom metrics file path.
+        """
+        if value:
+            self.config.set({"dcgm-exporter-metrics-file": str(value)})
+        else:
+            self.config.unset("dcgm-exporter-metrics-file")
+
+    def get_nv_hostengine_port(self) -> int | None:
+        """Get the port that the NV-Hostengine is listening on.
+
+        Notes:
+            - The default port number is 5555.
+            - `None` is returned if the output of 'snap get -d dcgm' does not
+              contain a configured port for the NV-Hostengine service.
+        """
+        try:
+            return self.config.get("nv-hostengine-port")
+        except SnapError:
+            # `SnapError` is raised if `nv-hostengine-port` option is empty.
+            return None
+
+    def set_nv_hostengine_port(self, value: int | None) -> None:
+        """Set the port that the NV-Hostengine is listening on.
+
+        Args:
+            value: The port to use for the NV-Hostengine service.
+
+        Notes:
+            - Providing the value `None` will unset the custom port number.
+        """
+        if value is not None:
+            self.config.set({"nv-hostengine-port": value})
+        else:
+            self.config.unset("nv-hostengine-port")

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -24,6 +24,7 @@ __all__ = [
 
 import json
 from collections.abc import Mapping
+from functools import cached_property
 from subprocess import CalledProcessError
 from typing import Any
 
@@ -103,47 +104,6 @@ class SnapConfigManager:
         snap("unset", self._snap, *keys)
 
 
-class SnapOpsManager(OpsManager):
-    """Control the operations of a `snap` package."""
-
-    def __init__(self, snap: str) -> None:
-        self._snap = snap
-
-    def install(self) -> None:
-        """Install package."""
-        snap("install", self._snap)
-
-    def remove(self, *, purge: bool = False) -> None:
-        """Remove package.
-
-        Args:
-            purge: Remove the package without saving a snapshot of its data. Default: False.
-        """
-        command = ["remove", self._snap]
-        if purge:
-            command.append("--purge")
-
-        snap(*command)
-
-    def connect(self, plug: str, *, service: str | None = None, slot: str | None = None) -> None:
-        """Connect a plug to a slot.
-
-        Args:
-            plug: The plug to connect.
-            service: The snap service name to plug into.
-            slot: The snap service slot to plug in to.
-        """
-        command = ["connect", f"{self._snap}:{plug}"]
-        if service and slot:
-            command.append(f"{service}:{slot}")
-        elif service:
-            command.append(service)
-        elif slot:
-            command.append(f":{slot}")
-
-        snap(*command)
-
-
 class SnapServiceManager(ServiceManager):
     """Control a service using `snap`.
 
@@ -197,24 +157,67 @@ class SnapServiceManager(ServiceManager):
         return "inactive" not in services[self._service]
 
 
+class SnapOpsManager(OpsManager):
+    """Control the operations of a `snap` package."""
+
+    def __init__(self, snap: str) -> None:
+        self._snap = snap
+
+    def service_manager_for(self, service: str) -> SnapServiceManager:
+        """Create a service manager for the given service name.
+
+        Args:
+            service: Name of the service to create a `SnapServiceManager` for.
+        """
+        return SnapServiceManager(service, snap=self._snap if service != self._snap else None)
+
+    def install(self) -> None:
+        """Install package."""
+        snap("install", self._snap)
+
+    def remove(self, *, purge: bool = False) -> None:
+        """Remove package.
+
+        Args:
+            purge: Remove the package without saving a snapshot of its data. Default: False.
+        """
+        command = ["remove", self._snap]
+        if purge:
+            command.append("--purge")
+
+        snap(*command)
+
+    def connect(self, plug: str, *, service: str | None = None, slot: str | None = None) -> None:
+        """Connect a plug to a slot.
+
+        Args:
+            plug: The plug to connect.
+            service: The snap service name to plug into.
+            slot: The snap service slot to plug in to.
+        """
+        command = ["connect", f"{self._snap}:{plug}"]
+        if service and slot:
+            command.append(f"{service}:{slot}")
+        elif service:
+            command.append(service)
+        elif slot:
+            command.append(f":{slot}")
+
+        snap(*command)
+
+
 class SnapLifecycleManager:
     """Manage the full lifecycle operations of a snapped application."""
 
-    def __init__(self, snap: str, /, service: str = "") -> None:
-        self._config_manager = SnapConfigManager(snap)
+    def __init__(self, snap: str, /) -> None:
+        self._snap = snap
         self._ops_manager = SnapOpsManager(snap)
-        self._service_manager = SnapServiceManager(service or snap, snap=snap if service else None)
 
         self.install = self._ops_manager.install
         self.remove = self._ops_manager.remove
         self.connect = self._ops_manager.connect
 
-    @property
+    @cached_property
     def config(self) -> SnapConfigManager:
         """Manage the snap configuration."""
-        return self._config_manager
-
-    @property
-    def service(self) -> SnapServiceManager:
-        """Manage the snapped service."""
-        return self._service_manager
+        return SnapConfigManager(self._snap)

--- a/tests/unit/ops/test_exporters.py
+++ b/tests/unit/ops/test_exporters.py
@@ -37,6 +37,11 @@ class TestNodeExporterManager:
         """Create a `NodeExporterManager` object."""
         return NodeExporterManager()
 
+    def test_service(self, node_exporter_manager, mock_snap) -> None:
+        """Test the `service` property."""
+        node_exporter_manager.service.start()
+        mock_snap.assert_called_with("start", "node-exporter")
+
     def test_get_collectors(self, node_exporter_manager, mock_snap) -> None:
         """Test the `get_collectors` method."""
         mock_snap.return_value = ('{"collectors": "ntp cpu"}', 0)

--- a/tests/unit/ops/test_nvidia.py
+++ b/tests/unit/ops/test_nvidia.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `nvidia` library."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from charmed_hpc_libs.errors import SnapError
+from charmed_hpc_libs.ops import DCGMManager
+
+
+@pytest.fixture(scope="function")
+def mock_snap(mocker: MockerFixture) -> Mock:
+    """Create a mocked `snap` function."""
+    return mocker.patch("charmed_hpc_libs.ops.machine.snap.snap")
+
+
+class TestDCGMManager:
+    """Test the `DCGMManager` class."""
+
+    @pytest.fixture
+    def dcgm_manager(self) -> DCGMManager:
+        """Create a `DCGMManager` object."""
+        return DCGMManager()
+
+    def test_exporter_service(self, dcgm_manager, mock_snap) -> None:
+        """Test the `exporter` property returns a manager for the dcgm-exporter service."""
+        dcgm_manager.exporter.start()
+        mock_snap.assert_called_with("start", "dcgm.dcgm-exporter")
+
+    def test_nv_hostengine_service(self, dcgm_manager, mock_snap) -> None:
+        """Test the `nv_hostengine` property returns a manager for the nv-hostengine service."""
+        dcgm_manager.nv_hostengine.start()
+        mock_snap.assert_called_with("start", "dcgm.nv-hostengine")
+
+    def test_get_dcgm_exporter_address(self, dcgm_manager, mock_snap) -> None:
+        """Test the `get_dcgm_exporter_address` method returns the configured address."""
+        mock_snap.return_value = ('{"dcgm-exporter-address": ":9400"}', 0)
+        assert dcgm_manager.get_dcgm_exporter_address() == ":9400"
+
+        dcgm_manager.set_dcgm_exporter_address(":9401")
+        mock_snap.assert_called_with("set", "dcgm", 'dcgm-exporter-address=":9401"')
+
+        dcgm_manager.set_dcgm_exporter_address("")
+        mock_snap.assert_called_with("unset", "dcgm", "dcgm-exporter-address")
+
+        mock_snap.side_effect = SnapError(
+            "error: snap 'dcgm' has no 'dcgm-exporter-address' configuration option"
+        )
+        assert dcgm_manager.get_dcgm_exporter_address() == ""
+
+    def test_get_dcgm_exporter_metrics_file(self, dcgm_manager, mock_snap) -> None:
+        """Test `get_dcgm_exporter_metrics_file` returns the configured metrics file path."""
+        mock_snap.return_value = ('{"dcgm-exporter-metrics-file": "/etc/dcgm/custom.csv"}', 0)
+        assert dcgm_manager.get_dcgm_exporter_metrics_file() == Path("/etc/dcgm/custom.csv")
+
+        dcgm_manager.set_dcgm_exporter_metrics_file("/etc/dcgm/custom.csv")
+        mock_snap.assert_called_with(
+            "set", "dcgm", 'dcgm-exporter-metrics-file="/etc/dcgm/custom.csv"'
+        )
+
+        dcgm_manager.set_dcgm_exporter_metrics_file(Path("/etc/dcgm/custom.csv"))
+        mock_snap.assert_called_with(
+            "set", "dcgm", 'dcgm-exporter-metrics-file="/etc/dcgm/custom.csv"'
+        )
+
+        dcgm_manager.set_dcgm_exporter_metrics_file("")
+        mock_snap.assert_called_with("unset", "dcgm", "dcgm-exporter-metrics-file")
+
+        mock_snap.side_effect = SnapError(
+            "error: snap 'dcgm' has no 'dcgm-exporter-metrics-file' configuration option"
+        )
+        assert dcgm_manager.get_dcgm_exporter_metrics_file() == Path()
+
+    def test_get_nv_hostengine_port(self, dcgm_manager, mock_snap) -> None:
+        """Test `get_nv_hostengine_port` returns the configured port number."""
+        mock_snap.return_value = ('{"nv-hostengine-port": 5556}', 0)
+        assert dcgm_manager.get_nv_hostengine_port() == 5556
+
+        dcgm_manager.set_nv_hostengine_port(5556)
+        mock_snap.assert_called_with("set", "dcgm", "nv-hostengine-port=5556")
+
+        dcgm_manager.set_nv_hostengine_port(None)
+        mock_snap.assert_called_with("unset", "dcgm", "nv-hostengine-port")
+
+        mock_snap.side_effect = SnapError(
+            "error: snap 'dcgm' has no 'nv-hostengine-port' configuration option"
+        )
+        assert dcgm_manager.get_nv_hostengine_port() is None

--- a/tests/unit/ops/test_nvidia.py
+++ b/tests/unit/ops/test_nvidia.py
@@ -85,7 +85,7 @@ class TestDCGMManager:
         mock_snap.side_effect = SnapError(
             "error: snap 'dcgm' has no 'dcgm-exporter-metrics-file' configuration option"
         )
-        assert dcgm_manager.get_dcgm_exporter_metrics_file() == Path()
+        assert dcgm_manager.get_dcgm_exporter_metrics_file() is None
 
     def test_get_nv_hostengine_port(self, dcgm_manager, mock_snap) -> None:
         """Test `get_nv_hostengine_port` returns the configured port number."""

--- a/tests/unit/ops/test_snap.py
+++ b/tests/unit/ops/test_snap.py
@@ -23,7 +23,6 @@ from pytest_mock import MockerFixture
 from charmed_hpc_libs.errors import SnapError
 from charmed_hpc_libs.ops import (
     SnapConfigManager,
-    SnapLifecycleManager,
     SnapOpsManager,
     SnapServiceManager,
     snap,
@@ -279,22 +278,3 @@ class TestSnapServiceManager:
                 assert exec_info.value.message == (
                     "cannot retrieve 'slurm.slurmctld' service info with 'snap info slurm'"
                 )
-
-
-class TestSnapLifecycleManager:
-    """Test the `SnapLifecycleManager` class."""
-
-    @pytest.fixture
-    def lifecycle_manager(self) -> SnapLifecycleManager:
-        """Create a `SnapLifecycleManager` object."""
-        return SnapLifecycleManager("slurm")
-
-    def test_config(self, lifecycle_manager, mock_snap) -> None:
-        """Test the `config` property."""
-        mock_snap.return_value = ('{"exporter.port": 9100}', 0)
-        assert lifecycle_manager.config.get("exporter.port") == 9100
-
-    def test_service(self, lifecycle_manager, mock_snap) -> None:
-        """Test the `service` property."""
-        lifecycle_manager.service.start()
-        mock_snap.assert_called_with("start", "slurm")


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR introduces the `DCGMManager` class to manage Nvidia's Data Center GPU Manager software. This snap package provides the `dcgm-exporter` which we need to pull metrics from Nvidia GPUs.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to our ongoing work to add alerts for Nvidia GPUs to Charmed HPC.

### Other changes

I modified the `SnapLifecycleManager` class to not include the `service` property. I found this initial design decision to be too restrictive for more advanced snap packages such as `dcgm`. To get around this conundrum, I brought over the `service_manager_for` method from `slurm-ops` and lazily create service managers when requested. I use `cached_property` here to ensure that same object is returned each time the property is accessed. This is useful for when we access a service/config multiple times within the same hook execution.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change for supporting GPU-related operations in Charmed HPC.