### PR TITLE
chore: migrate CODEOWNERS to canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-** @charmed-hpc/python-reviewers
+** @canonical/hpc-code-reviewers


### PR DESCRIPTION
Update CODEOWNERS to use @canonical/hpc-code-reviewers.