### PR TITLE
chore: update docs link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,9 +19,9 @@
 
 ## Docs
 
-* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.
+* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.
 
-[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)
+[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)
 
 Or:
 


### PR DESCRIPTION
Update the documentation link from charmed-hpc/docs to canonical/charmed-hpc-docs.