### PR TITLE
fix: pass PYPI_PUBLISH_TOKEN to reusable PyPI publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,12 @@ jobs:
 
   tag-and-release:
     needs: ci
+    permissions:
+      contents: write
     uses: canonical/hpc-team/.github/workflows/release-python-package.yaml@main
 
   publish:
     needs: [ci, tag-and-release]
     uses: canonical/hpc-team/.github/workflows/publish-python-package.yaml@main
+    secrets:
+      PYPI_PUBLISH_TOKEN: ${{ secrets.PYPI_PUBLISH_TOKEN }}


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Pass `PYPI_PUBLISH_TOKEN` to the reusable `publish-python-package.yaml` workflow from `canonical/hpc-team`, which now requires this secret to be explicitly provided by the caller instead of relying on a GitHub environment.

Also add explicit `permissions: contents: write` to the `tag-and-release` job to ensure the reusable `release-python-package.yaml` workflow can push git tags, matching the established pattern in `canonical/slurmutils`.

#### Related Issues, PRs, and Discussions

N/A &mdash; chore/fix for updated reusable workflow interface.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.