### PR TITLE
feat: add `reload` method to `ServiceManager` protocol

### DIFF
--- a/src/charmed_hpc_libs/ops/core/service.py
+++ b/src/charmed_hpc_libs/ops/core/service.py
@@ -44,5 +44,9 @@ class ServiceManager(Protocol):  # pragma: no cover
         raise NotImplementedError
 
     @abstractmethod
+    def reload(self) -> None:  # noqa D102
+        raise NotImplementedError
+
+    @abstractmethod
     def is_active(self) -> bool:  # noqa D102
         raise NotImplementedError

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -143,6 +143,10 @@ class SnapServiceManager(ServiceManager):
         """Restart service."""
         snap("restart", self._service)
 
+    def reload(self) -> None:
+        """Reload service."""
+        snap("restart", "--reload", self._service)
+
     def is_active(self) -> bool:
         """Check if service is active."""
         info = yaml.safe_load(snap("info", self._snap)[0])

--- a/src/charmed_hpc_libs/ops/machine/systemd.py
+++ b/src/charmed_hpc_libs/ops/machine/systemd.py
@@ -91,6 +91,10 @@ class SystemctlServiceManager(ServiceManager):
         """Restart service."""
         systemctl("restart", self._service)
 
+    def reload(self) -> None:
+        """Reload service."""
+        systemctl("reload", self._service)
+
     def is_active(self) -> bool:
         """Check if service is active."""
         _, exit_code = systemctl("is-active", "--quiet", self._service, check=False)

--- a/tests/unit/ops/test_snap.py
+++ b/tests/unit/ops/test_snap.py
@@ -240,6 +240,14 @@ class TestSnapServiceManager:
         else:
             mock_snap.assert_called_with("restart", "slurm.slurmctld")
 
+    def test_reload(self, service_manager, mock_snap, service_name_is_snap_name) -> None:
+        """Test the `reload` method."""
+        service_manager.reload()
+        if service_name_is_snap_name:
+            mock_snap.assert_called_with("restart", "--reload", "slurmctld")
+        else:
+            mock_snap.assert_called_with("restart", "--reload", "slurm.slurmctld")
+
     @pytest.mark.parametrize(
         "mock_result,installed",
         (

--- a/tests/unit/ops/test_systemd.py
+++ b/tests/unit/ops/test_systemd.py
@@ -121,6 +121,11 @@ class TestSystemctlServiceManager:
         service_manager.restart()
         mock_systemctl.assert_called_with("restart", "slurmctld")
 
+    def test_reload(self, service_manager, mock_systemctl) -> None:
+        """Test the `reload` method."""
+        service_manager.reload()
+        mock_systemctl.assert_called_with("reload", "slurmctld")
+
     @pytest.mark.parametrize(
         "mock_result,expected",
         (


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds a `reload` method to the `ServiceManager` protocol, and provides an implementation for `reload` on both the `SnapServiceManager` and `SystemctlServiceManager` classes.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/canonical/charmed-hpc-libs/issues/126

The request for `reload` emerged as part of feature work on the Slurm charms, and I am working on cleaning up pieces of `charmed-hpc-libs` as there are additional pieces I might add for the `openssh-operator` work.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change in our HPC charm development SDK.