### PR TITLE
feat: add `is_installed` method to `OpsManager` protocol

### DIFF
--- a/src/charmed_hpc_libs/ops/core/operations.py
+++ b/src/charmed_hpc_libs/ops/core/operations.py
@@ -36,3 +36,7 @@ class OpsManager(Protocol):  # pragma: no cover
     @abstractmethod
     def remove(self) -> None:  # noqa D102
         raise NotImplementedError
+
+    @abstractmethod
+    def is_installed(self) -> bool:  # noqa D102
+        raise NotImplementedError

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -187,6 +187,11 @@ class SnapOpsManager(OpsManager):
 
         snap(*command)
 
+    def is_installed(self) -> bool:
+        """Check if the snap package is installed."""
+        _, exit_code = snap("list", self._snap, check=False)
+        return exit_code == 0
+
     def connect(self, plug: str, *, service: str | None = None, slot: str | None = None) -> None:
         """Connect a plug to a slot.
 
@@ -215,6 +220,7 @@ class SnapLifecycleManager:
 
         self.install = self._ops_manager.install
         self.remove = self._ops_manager.remove
+        self.is_installed = self._ops_manager.is_installed
         self.connect = self._ops_manager.connect
 
     @cached_property

--- a/tests/unit/ops/test_snap.py
+++ b/tests/unit/ops/test_snap.py
@@ -182,6 +182,19 @@ class TestSnapOpsManager:
         ops_manager.connect("network-observe", service="snapd")
         mock_snap.assert_called_with("connect", "slurm:network-observe", "snapd")
 
+    @pytest.mark.parametrize(
+        "mock_return,expected",
+        (
+            pytest.param(("", 0), True, id="installed"),
+            pytest.param(("", 1), False, id="not installed"),
+        ),
+    )
+    def test_is_installed(self, ops_manager, mock_snap, mock_return, expected) -> None:
+        """Test the `is_installed` method."""
+        mock_snap.return_value = mock_return
+        assert ops_manager.is_installed() is expected
+        mock_snap.assert_called_with("list", "slurm", check=False)
+
 
 @pytest.mark.parametrize(
     "service_name_is_snap_name",


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds the `is_installed` method to the `OpsManager` protocol, and it adds an `is_installed` method to the `SnapOpsManager` class.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/canonical/charmed-hpc-libs/issues/133

This issue was originally generated from a FIXME comment added to some feature work in the Slurm charms: https://github.com/canonical/slurm-charms/pull/215. I'm cleaning up `charmed-hpc-libs` as I work on some potential new features I need in the `openssh` operator.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing change in our HPC charm development SDK.