### PR TITLE
feat: add `version` method to `OpsManager` protocol

### DIFF
--- a/src/charmed_hpc_libs/ops/core/operations.py
+++ b/src/charmed_hpc_libs/ops/core/operations.py
@@ -40,3 +40,7 @@ class OpsManager(Protocol):  # pragma: no cover
     @abstractmethod
     def is_installed(self) -> bool:  # noqa D102
         raise NotImplementedError
+
+    @abstractmethod
+    def version(self) -> str:  # noqa D102
+        raise NotImplementedError

--- a/src/charmed_hpc_libs/ops/machine/snap.py
+++ b/src/charmed_hpc_libs/ops/machine/snap.py
@@ -196,6 +196,16 @@ class SnapOpsManager(OpsManager):
         _, exit_code = snap("list", self._snap, check=False)
         return exit_code == 0
 
+    def version(self) -> str:
+        """Get the version of the installed snap package."""
+        info = yaml.safe_load(snap("info", self._snap)[0])
+        version = info.get("installed")
+        if version is None:
+            raise SnapError(
+                f"unable to retrieve snap info. ensure {self._snap} is correctly installed"
+            )
+        return version.split(maxsplit=1)[0]
+
     def connect(self, plug: str, *, service: str | None = None, slot: str | None = None) -> None:
         """Connect a plug to a slot.
 
@@ -225,6 +235,7 @@ class SnapLifecycleManager:
         self.install = self._ops_manager.install
         self.remove = self._ops_manager.remove
         self.is_installed = self._ops_manager.is_installed
+        self.version = self._ops_manager.version
         self.connect = self._ops_manager.connect
 
     @cached_property

--- a/tests/unit/ops/test_snap.py
+++ b/tests/unit/ops/test_snap.py
@@ -195,6 +195,27 @@ class TestSnapOpsManager:
         assert ops_manager.is_installed() is expected
         mock_snap.assert_called_with("list", "slurm", check=False)
 
+    @pytest.mark.parametrize(
+        "mock_result,expected",
+        (
+            pytest.param((SNAP_INFO, 0), "23.11.7", id="installed"),
+            pytest.param((SNAP_INFO_NOT_INSTALLED, 1), None, id="not installed"),
+        ),
+    )
+    def test_version(self, ops_manager, mock_snap, mock_result, expected) -> None:
+        """Test the `version` method."""
+        mock_snap.return_value = mock_result
+        if expected is not None:
+            assert ops_manager.version() == expected
+            mock_snap.assert_called_with("info", "slurm")
+        else:
+            with pytest.raises(SnapError) as exec_info:
+                ops_manager.version()
+            assert exec_info.value.message == (
+                "unable to retrieve snap info. ensure slurm is correctly installed"
+            )
+            mock_snap.assert_called_with("info", "slurm")
+
 
 @pytest.mark.parametrize(
     "service_name_is_snap_name",


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds a `version` method to the `OpsManager` protocol, and implements of the `version` method on the `SnapOpsManager` class. The implementation is borrowed from the `slurm-ops` package in `slurm-charms`, but generalized to be applicable for all HPC charms that implement an operations manager class.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/canonical/charmed-hpc-libs/issues/145

I need the `version` method for some work that I'm doing on the `OpenSSHManager` class that I'm working on.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing change to our HPC charm development SDK.