### PR TITLE
feat: add `AptOpsManager` and `AptLifecycleManager` classes 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charmed-hpc-libs"
-version = "0.3.0"
+version = "0.4.0"
 requires-python = ">=3.12"
 description = "Collection of utilities to manage HPC related services."
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,9 +91,6 @@ branch = true
 include = [
     "src/**/*.py"
 ]
-omit = [
-    "src/**/machine/apt.py"
-]
 
 [tool.coverage.report]
 show_missing = true
@@ -104,7 +101,7 @@ log_cli_level = "INFO"
 
 # Spell checking tools configuration
 [tool.codespell]
-skip = "lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.pytest_cache,.vscode,.coverage,.venv,cover,./src/hpc_libs/machine/apt.py"
+skip = "lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.pytest_cache,.vscode,.coverage,.venv,cover"
 
 # Linting tools configuration
 [tool.ruff]
@@ -138,4 +135,3 @@ max-complexity = 15
 
 [tool.pyright]
 include = ["src/*"]
-exclude = ["**/machine/apt.py"]

--- a/src/charmed_hpc_libs/errors/__init__.py
+++ b/src/charmed_hpc_libs/errors/__init__.py
@@ -15,6 +15,7 @@
 """Errors raised by functions and methods in HPC charms."""
 
 __all__ = [
+    "AptError",
     "Error",
     "IngressAddressNotFoundError",
     "SnapError",
@@ -34,6 +35,10 @@ class Error(Exception):
 
 class IngressAddressNotFoundError(Error):
     """Error raised if a charm is unable to access its ingress address."""
+
+
+class AptError(Error):
+    """Error raised if an `apt`-related operation fails."""
 
 
 class SnapError(Error):

--- a/src/charmed_hpc_libs/ops/__init__.py
+++ b/src/charmed_hpc_libs/ops/__init__.py
@@ -16,6 +16,7 @@
 
 __all__ = [
     # From `apt.py`
+    "AptLifecycleManager",
     "AptOpsManager",
     "apt",
     "dpkg_query",
@@ -69,6 +70,7 @@ from .core import OpsManager, ServiceManager, call
 from .env import EnvManager
 from .exporters import NodeExporterManager
 from .machine import (
+    AptLifecycleManager,
     AptOpsManager,
     DCGMManager,
     SnapConfigManager,

--- a/src/charmed_hpc_libs/ops/__init__.py
+++ b/src/charmed_hpc_libs/ops/__init__.py
@@ -15,6 +15,10 @@
 """Libraries for building HPC charms."""
 
 __all__ = [
+    # From `apt.py`
+    "AptOpsManager",
+    "apt",
+    "dpkg_query",
     # From `conditions.py`
     "Condition",
     "ConditionEvaluation",
@@ -65,12 +69,15 @@ from .core import OpsManager, ServiceManager, call
 from .env import EnvManager
 from .exporters import NodeExporterManager
 from .machine import (
+    AptOpsManager,
     DCGMManager,
     SnapConfigManager,
     SnapLifecycleManager,
     SnapOpsManager,
     SnapServiceManager,
     SystemctlServiceManager,
+    apt,
+    dpkg_query,
     is_container,
     snap,
     systemctl,

--- a/src/charmed_hpc_libs/ops/core/call.py
+++ b/src/charmed_hpc_libs/ops/core/call.py
@@ -21,7 +21,12 @@ _logger = logging.getLogger(__name__)
 
 
 def call(
-    root: str, /, *args: str, stdin: str | None = None, check: bool = True
+    root: str,
+    /,
+    *args: str,
+    stdin: str | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Call a command with logging enabled.
 
@@ -30,6 +35,8 @@ def call(
         args: Arguments to pass to the root command.
         stdin: Standard input to pipe into the root command.
         check: If set to `True`, raise an error if the command exits with a non-zero exit code.
+        env: Environment variables to pass to the root command. If set to `None`, the
+            current process's environment is used.
 
     Raises:
         subprocess.CalledProcessError:
@@ -38,7 +45,9 @@ def call(
     cmd = [root, *args]
     try:
         _logger.debug("running command %s", cmd)
-        result = subprocess.run(cmd, input=stdin, capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            cmd, input=stdin, capture_output=True, text=True, check=True, env=env
+        )
     except subprocess.CalledProcessError as e:
         _logger.error(
             "command '%s' failed with:\nexit code %s\nstderr: %s",

--- a/src/charmed_hpc_libs/ops/machine/__init__.py
+++ b/src/charmed_hpc_libs/ops/machine/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,10 @@
 """Libraries for interfacing with machine resources."""
 
 __all__ = [
+    # From `apt.py`
+    "AptOpsManager",
+    "apt",
+    "dpkg_query",
     # From `nvidia.py`
     "DCGMManager",
     # From `snap.py`
@@ -29,6 +33,7 @@ __all__ = [
     "is_container",
 ]
 
+from .apt import AptOpsManager, apt, dpkg_query
 from .nvidia import DCGMManager
 from .snap import SnapConfigManager, SnapLifecycleManager, SnapOpsManager, SnapServiceManager, snap
 from .systemd import SystemctlServiceManager, is_container, systemctl

--- a/src/charmed_hpc_libs/ops/machine/__init__.py
+++ b/src/charmed_hpc_libs/ops/machine/__init__.py
@@ -16,6 +16,7 @@
 
 __all__ = [
     # From `apt.py`
+    "AptLifecycleManager",
     "AptOpsManager",
     "apt",
     "dpkg_query",
@@ -33,7 +34,7 @@ __all__ = [
     "is_container",
 ]
 
-from .apt import AptOpsManager, apt, dpkg_query
+from .apt import AptLifecycleManager, AptOpsManager, apt, dpkg_query
 from .nvidia import DCGMManager
 from .snap import SnapConfigManager, SnapLifecycleManager, SnapOpsManager, SnapServiceManager, snap
 from .systemd import SystemctlServiceManager, is_container, systemctl

--- a/src/charmed_hpc_libs/ops/machine/apt.py
+++ b/src/charmed_hpc_libs/ops/machine/apt.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Control `apt-get` and `dpkg-query` in HPC machine charms."""
+
+__all__ = [
+    "AptOpsManager",
+    "apt",
+    "dpkg_query",
+]
+
+import os
+from collections.abc import Iterable
+from subprocess import CalledProcessError
+from typing import Any
+
+from ...errors import AptError
+from ..core import OpsManager, call
+from .systemd import SystemctlServiceManager
+
+
+def apt(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
+    """Control Debian/Ubuntu packages using `apt-get ...` commands.
+
+    Keyword Args:
+        stdin: Standard input to pipe to the `apt-get` command.
+        check:
+            If set to `True`, raise an error if the `apt-get` command
+            exits with a non-zero exit code.
+
+    Raises:
+        AptError: Raised if an `apt-get` command fails and check is set to `True`.
+    """
+    env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
+    try:
+        result = call("apt-get", *args, env=env, **kwargs)
+    except CalledProcessError as e:
+        raise AptError(
+            f"apt-get command '{' '.join(e.cmd)}' failed with exit code {e.returncode}. "
+            + f"reason: {e.stderr}"
+        )
+
+    return result.stdout, result.returncode
+
+
+def dpkg_query(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
+    """Query `dpkg` for package information using `dpkg-query ...` commands.
+
+    Keyword Args:
+        stdin: Standard input to pipe to the `dpkg-query` command.
+        check:
+            If set to `True`, raise an error if the `dpkg-query` command
+            exits with a non-zero exit code.
+
+    Raises:
+        AptError: Raised if a `dpkg-query` command fails and check is set to `True`.
+    """
+    try:
+        result = call("dpkg-query", *args, **kwargs)
+    except CalledProcessError as e:
+        raise AptError(
+            f"dpkg-query command '{' '.join(e.cmd)}' failed with exit code {e.returncode}. "
+            + f"reason: {e.stderr}"
+        )
+
+    return result.stdout, result.returncode
+
+
+class AptOpsManager(OpsManager):
+    """Control the operations of an `apt` package."""
+
+    def __init__(self, package: str, *, additional_packages: Iterable[str] | None = None) -> None:
+        self._package = package
+        self._additional_packages = list(additional_packages) if additional_packages else []
+
+    def service_manager_for(self, service: str) -> SystemctlServiceManager:  # noqa D102
+        """Create a service manager for the provided service name.
+
+        Args:
+            service: Name of the service to create a ``SystemctlServiceManager`` for.
+        """
+        return SystemctlServiceManager(service)
+
+    def update(self) -> None:
+        """Update the ``apt`` package cache."""
+        apt("update")
+
+    def install(self, *, update: bool = True) -> None:
+        """Install packages.
+
+        Args:
+            update:
+                If ``True``, update the ``apt`` cache by running ``apt-get update``
+                before installing packages.
+        """
+        if update:
+            self.update()
+
+        apt("install", "-y", self._package, *self._additional_packages)
+
+    def remove(self, *, purge: bool = False) -> None:
+        """Remove packages.
+
+        Args:
+            purge:
+                If ``True``, removed packages are also purged (configuration files are also deleted).
+        """
+        command = ["remove", "-y", self._package]
+        if self._additional_packages:
+            command.extend(self._additional_packages)
+        if purge:
+            command.append("--purge")
+
+        apt(*command)
+
+    def is_installed(self) -> bool:
+        """Check if the ``apt`` package is installed."""
+        _, exit_code = dpkg_query("-W", self._package, check=False)
+        return exit_code == 0
+
+    def version(self) -> str:
+        """Get the version of primary ``apt`` package."""
+        result, exit_code = dpkg_query(
+            "-W", "-f=${source:Upstream-Version}", self._package, check=False
+        )
+        if exit_code != 0:
+            raise AptError(
+                f"unable to retrieve {self._package} version. "
+                f"ensure {self._package} is correctly installed"
+            )
+
+        return result

--- a/src/charmed_hpc_libs/ops/machine/apt.py
+++ b/src/charmed_hpc_libs/ops/machine/apt.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Control `apt-get` and `dpkg-query` in HPC machine charms."""
+"""Control ``apt-get`` and ``dpkg-query`` in HPC machine charms."""
 
 __all__ = [
+    "AptLifecycleManager",
     "AptOpsManager",
     "apt",
     "dpkg_query",
@@ -31,16 +32,16 @@ from .systemd import SystemctlServiceManager
 
 
 def apt(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
-    """Control Debian/Ubuntu packages using `apt-get ...` commands.
+    """Control Debian/Ubuntu packages using ``apt-get ...`` commands.
 
     Keyword Args:
-        stdin: Standard input to pipe to the `apt-get` command.
+        stdin: Standard input to pipe to the ``apt-get`` command.
         check:
-            If set to `True`, raise an error if the `apt-get` command
+            If set to `True`, raise an error if the ``apt-get`` command
             exits with a non-zero exit code.
 
     Raises:
-        AptError: Raised if an `apt-get` command fails and check is set to `True`.
+        AptError: Raised if an ``apt-get`` command fails and check is set to ``True``.
     """
     env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
     try:
@@ -55,16 +56,16 @@ def apt(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
 
 
 def dpkg_query(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
-    """Query `dpkg` for package information using `dpkg-query ...` commands.
+    """Query ``dpkg`` for package information using ``dpkg-query ...`` commands.
 
     Keyword Args:
-        stdin: Standard input to pipe to the `dpkg-query` command.
+        stdin: Standard input to pipe to the ``dpkg-query`` command.
         check:
-            If set to `True`, raise an error if the `dpkg-query` command
+            If set to `True`, raise an error if the ``dpkg-query`` command
             exits with a non-zero exit code.
 
     Raises:
-        AptError: Raised if a `dpkg-query` command fails and check is set to `True`.
+        AptError: Raised if a ``dpkg-query`` command fails and check is set to ``True``.
     """
     try:
         result = call("dpkg-query", *args, **kwargs)
@@ -78,7 +79,7 @@ def dpkg_query(*args: str, **kwargs: Any) -> tuple[str, int]:  # noqa D417
 
 
 class AptOpsManager(OpsManager):
-    """Control the operations of an `apt` package."""
+    """Control the operations of an ``apt`` package."""
 
     def __init__(self, package: str, *, additional_packages: Iterable[str] | None = None) -> None:
         self._package = package
@@ -141,3 +142,18 @@ class AptOpsManager(OpsManager):
             )
 
         return result
+
+
+class AptLifecycleManager:
+    """Manage the full lifecycle operations of an ``apt`` package."""
+
+    def __init__(
+        self, package: str, /, *, additional_packages: Iterable[str] | None = None
+    ) -> None:
+        self._ops_manager = AptOpsManager(package, additional_packages=additional_packages)
+
+        self.update = self._ops_manager.update
+        self.install = self._ops_manager.install
+        self.remove = self._ops_manager.remove
+        self.is_installed = self._ops_manager.is_installed
+        self.version = self._ops_manager.version

--- a/tests/unit/ops/test_apt.py
+++ b/tests/unit/ops/test_apt.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the `apt` machine library."""
+
+import subprocess
+from unittest.mock import Mock, call
+
+import pytest
+from pytest_mock import MockerFixture
+
+from charmed_hpc_libs.errors import AptError
+from charmed_hpc_libs.ops import AptOpsManager, apt, dpkg_query
+
+
+def test_apt(mocker: MockerFixture) -> None:
+    """Test the `apt` function."""
+    mock_run = mocker.patch.object(subprocess, "run")
+    mock_run.side_effect = subprocess.CalledProcessError(
+        cmd=["apt-get", "install", "-y", "slurm"],
+        returncode=1,
+        output="",
+        stderr="failed to install slurm",
+    )
+
+    stdout, exit_code = apt("install", "-y", "slurm", check=False)
+    assert stdout is None
+    assert exit_code == 1
+
+    with pytest.raises(AptError) as exec_info:
+        apt("install", "-y", "slurm", check=True)
+
+    assert exec_info.type == AptError
+    assert exec_info.value.message == (
+        "apt-get command 'apt-get install -y slurm' failed with exit code 1. "
+        + "reason: failed to install slurm"
+    )
+
+
+def test_dpkg_query(mocker: MockerFixture) -> None:
+    """Test the `dpkg_query` function."""
+    mock_run = mocker.patch.object(subprocess, "run")
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["dpkg-query", "-W", "slurm"],
+        returncode=0,
+        stdout="23.11.7",
+    )
+
+    stdout, exit_code = dpkg_query("-W", "slurm")
+    assert stdout == "23.11.7"
+    assert exit_code == 0
+
+    mock_run.side_effect = subprocess.CalledProcessError(
+        cmd=["dpkg-query", "-W", "slurm"],
+        returncode=1,
+        output="",
+        stderr="package slurm is not installed",
+    )
+
+    with pytest.raises(AptError) as exec_info:
+        dpkg_query("-W", "slurm")
+
+    assert exec_info.type == AptError
+    assert exec_info.value.message == (
+        "dpkg-query command 'dpkg-query -W slurm' failed with exit code 1. "
+        + "reason: package slurm is not installed"
+    )
+
+
+@pytest.fixture
+def mock_apt(mocker: MockerFixture) -> Mock:
+    """Create a mocked `apt` function."""
+    return mocker.patch("charmed_hpc_libs.ops.machine.apt.apt")
+
+
+@pytest.fixture
+def mock_dpkg_query(mocker: MockerFixture) -> Mock:
+    """Create a mocked `dpkg_query` function."""
+    return mocker.patch("charmed_hpc_libs.ops.machine.apt.dpkg_query")
+
+
+class TestAptOpsManager:
+    """Test the `AptOpsManager` class."""
+
+    @pytest.fixture
+    def ops_manager(self) -> AptOpsManager:
+        """Create an `AptOpsManager` object."""
+        return AptOpsManager("slurm")
+
+    @pytest.fixture
+    def ops_manager_with_extras(self) -> AptOpsManager:
+        """Create an `AptOpsManager` object with additional packages."""
+        return AptOpsManager("slurmctld", additional_packages=["slurm-client", "libpmix-dev"])
+
+    def test_install_with_update(self, ops_manager, mock_apt) -> None:
+        """Test the `install` method with cache update."""
+        ops_manager.install()
+        mock_apt.assert_has_calls([call("update"), call("install", "-y", "slurm")])
+
+    def test_install_without_update(self, ops_manager, mock_apt) -> None:
+        """Test the `install` method without cache update."""
+        ops_manager.install(update=False)
+        mock_apt.assert_called_with("install", "-y", "slurm")
+
+    def test_install_with_additional_packages(self, ops_manager_with_extras, mock_apt) -> None:
+        """Test the `install` method with additional packages."""
+        ops_manager_with_extras.install(update=False)
+        mock_apt.assert_called_with("install", "-y", "slurmctld", "slurm-client", "libpmix-dev")
+
+    def test_remove(self, ops_manager, mock_apt) -> None:
+        """Test the `remove` method."""
+        ops_manager.remove()
+        mock_apt.assert_called_with("remove", "-y", "slurm")
+
+    def test_remove_with_purge(self, ops_manager, mock_apt) -> None:
+        """Test the `remove` method with purge."""
+        ops_manager.remove(purge=True)
+        mock_apt.assert_called_with("remove", "-y", "slurm", "--purge")
+
+    def test_remove_with_additional_packages(self, ops_manager_with_extras, mock_apt) -> None:
+        """Test the `remove` method with additional packages."""
+        ops_manager_with_extras.remove()
+        mock_apt.assert_called_with("remove", "-y", "slurmctld", "slurm-client", "libpmix-dev")
+
+    @pytest.mark.parametrize(
+        "mock_return,expected",
+        (
+            pytest.param(("", 0), True, id="installed"),
+            pytest.param(("", 1), False, id="not installed"),
+        ),
+    )
+    def test_is_installed(self, ops_manager, mock_dpkg_query, mock_return, expected) -> None:
+        """Test the `is_installed` method."""
+        mock_dpkg_query.return_value = mock_return
+        assert ops_manager.is_installed() is expected
+        mock_dpkg_query.assert_called_with("-W", "slurm", check=False)
+
+    @pytest.mark.parametrize(
+        "mock_result,expected",
+        (
+            pytest.param(("23.11.7", 0), "23.11.7", id="installed"),
+            pytest.param(("", 1), None, id="not installed"),
+        ),
+    )
+    def test_version(self, ops_manager, mock_dpkg_query, mock_result, expected) -> None:
+        """Test the `version` method."""
+        mock_dpkg_query.return_value = mock_result
+        if expected is not None:
+            assert ops_manager.version() == expected
+            mock_dpkg_query.assert_called_with(
+                "-W", "-f=${source:Upstream-Version}", "slurm", check=False
+            )
+        else:
+            with pytest.raises(AptError) as exec_info:
+                ops_manager.version()
+            assert exec_info.value.message == (
+                "unable to retrieve slurm version. ensure slurm is correctly installed"
+            )
+
+    def test_update(self, ops_manager, mock_apt) -> None:
+        """Test the `update` method."""
+        ops_manager.update()
+        mock_apt.assert_called_with("update")

--- a/tests/unit/ops/test_apt.py
+++ b/tests/unit/ops/test_apt.py
@@ -21,7 +21,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from charmed_hpc_libs.errors import AptError
-from charmed_hpc_libs.ops import AptOpsManager, apt, dpkg_query
+from charmed_hpc_libs.ops import AptLifecycleManager, AptOpsManager, apt, dpkg_query
 
 
 def test_apt(mocker: MockerFixture) -> None:
@@ -171,4 +171,38 @@ class TestAptOpsManager:
     def test_update(self, ops_manager, mock_apt) -> None:
         """Test the `update` method."""
         ops_manager.update()
+        mock_apt.assert_called_with("update")
+
+
+class TestAptLifecycleManager:
+    """Test the `AptLifecycleManager` class."""
+
+    @pytest.fixture
+    def lifecycle_manager(self) -> AptLifecycleManager:
+        """Create an `AptLifecycleManager` object."""
+        return AptLifecycleManager("slurm")
+
+    def test_install(self, lifecycle_manager, mock_apt) -> None:
+        """Test the `install` method."""
+        lifecycle_manager.install()
+        mock_apt.assert_has_calls([call("update"), call("install", "-y", "slurm")])
+
+    def test_remove(self, lifecycle_manager, mock_apt) -> None:
+        """Test the `remove` method."""
+        lifecycle_manager.remove()
+        mock_apt.assert_called_with("remove", "-y", "slurm")
+
+    def test_is_installed(self, lifecycle_manager, mock_dpkg_query) -> None:
+        """Test the `is_installed` method."""
+        mock_dpkg_query.return_value = ("", 0)
+        assert lifecycle_manager.is_installed() is True
+
+    def test_version(self, lifecycle_manager, mock_dpkg_query) -> None:
+        """Test the `version` method."""
+        mock_dpkg_query.return_value = ("23.11.7", 0)
+        assert lifecycle_manager.version() == "23.11.7"
+
+    def test_update(self, lifecycle_manager, mock_apt) -> None:
+        """Test the `update` method."""
+        lifecycle_manager.update()
         mock_apt.assert_called_with("update")

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "charmed-hpc-libs"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds the `apt` module to the `ops` subpackage. The `apt` module contains both the `AptOpsManager` and `AptLifecycleManager` classes for building operations manager that rely on `apt` and `systemd` for driving the operations of a particular workload.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/canonical/charmed-hpc-libs/issues/146

I'll be using the `AptLifecycleManager` class in the new `openssh` operator to facilitate the service's operations. I opted for using our own apt module because (a) we all know the issues with `charmlibs-apt` and (b) using an operations manager class is more inline with how we're developing our charms.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing change to our HPC charm development SDK.