### PR TITLE
feat: add databag merging functionality to `_save_integration_data` method

### DIFF
--- a/src/charmed_hpc_libs/interfaces/interface.py
+++ b/src/charmed_hpc_libs/interfaces/interface.py
@@ -16,6 +16,7 @@
 
 __all__ = ["Interface"]
 
+import dataclasses
 from collections.abc import Callable, Iterable
 from typing import Any, Literal
 
@@ -217,6 +218,8 @@ class Interface(ops.Object):
         integration_id: int | None = None,
         *,
         encoder: Callable[[Any], str] | None = None,
+        merge: bool = False,
+        decoder: Callable[[str], Any] | None = None,
     ) -> None:
         """Save integration data.
 
@@ -225,13 +228,48 @@ class Interface(ops.Object):
             target: Location to save object.
             integration_id: ID of integration to update.
             encoder: Callable that will be used to encode each field.
+            merge:
+                Whether to merge data into the integration databag rather than
+                overwriting. When ``True``, only fields whose values differ from
+                their dataclass defaults are written; existing values for unset
+                fields are preserved.
+            decoder:
+                Callable used to decode existing databag data when merging.
+                Only used when ``merge`` is True.
         """
         integrations = self.integrations
         if integration_id is not None:
             integrations = [self.get_integration(integration_id)]
 
+        if not merge:
+            for integration in integrations:
+                integration.save(data, target, encoder=encoder)
+
+            return
+
+        cls = type(data)
+        if not dataclasses.is_dataclass(cls):
+            raise TypeError(f"`merge=True` requires a dataclass instance, got '{cls.__name__}'")
+
+        set_fields = {
+            f.name: getattr(data, f.name)
+            for f in dataclasses.fields(cls)
+            if not self._field_is_default(f, getattr(data, f.name))
+        }
+
         for integration in integrations:
-            integration.save(data, target, encoder=encoder)
+            existing = integration.load(cls, target, decoder=decoder)
+            merged = dataclasses.replace(existing, **set_fields)
+            integration.save(merged, target, encoder=encoder)
+
+    @staticmethod
+    def _field_is_default(field: dataclasses.Field, value: Any) -> bool:
+        """Check if a field value is equal to its declared default."""
+        if field.default is not dataclasses.MISSING:
+            return value == field.default
+        if field.default_factory is not dataclasses.MISSING:
+            return value == field.default_factory()
+        return False
 
     @staticmethod
     def _is_integration_active(integration: ops.Relation) -> bool:

--- a/tests/unit/interfaces/test_interface.py
+++ b/tests/unit/interfaces/test_interface.py
@@ -121,10 +121,10 @@ def with_id(request) -> bool:
 
 
 class TestInterface:
-    """Test the `Interface` base class."""
+    """Test the ``Interface`` base class."""
 
     def test_integrations(self, mock_charm, integration_exists) -> None:
-        """Test the `integrations` property."""
+        """Test the ``integrations`` property."""
         with mock_charm(
             mock_charm.on.update_status(),
             state=testing.State(relations={make_integration()} if integration_exists else {}),
@@ -134,7 +134,7 @@ class TestInterface:
         assert len(manager.charm.interface.integrations) == (1 if integration_exists else 0)
 
     def test_get_integration(self, mock_charm, integration_exists) -> None:
-        """Test the `get_integration` method."""
+        """Test the ``get_integration`` method."""
         with mock_charm(
             mock_charm.on.update_status(),
             state=testing.State(relations={make_integration(id=1)} if integration_exists else {}),
@@ -148,7 +148,7 @@ class TestInterface:
                 manager.charm.interface.get_integration()
 
     def test_is_joined(self, mock_charm, integration_exists) -> None:
-        """Test the `is_joined` method."""
+        """Test the ``is_joined`` method."""
         with mock_charm(
             mock_charm.on.update_status(),
             state=testing.State(relations={make_integration()} if integration_exists else {}),
@@ -168,7 +168,7 @@ class TestInterface:
     def test_is_ready(
         self, mock_charm, integration_exists, data_is_available, with_id, expected
     ) -> None:
-        """Test the `is_ready` method."""
+        """Test the ``is_ready`` method."""
         with mock_charm(
             mock_charm.on.update_status(),
             state=testing.State(
@@ -191,7 +191,7 @@ class TestInterface:
         ),
     )
     def test_load_integration_data(self, mock_charm, with_id, target) -> None:
-        """Test loading application data with the `_load_integration_data` method."""
+        """Test loading application data with the ``_load_integration_data`` method."""
         with mock_charm(
             mock_charm.on.update_status(),
             state=testing.State(
@@ -216,7 +216,7 @@ class TestInterface:
         assert data[0].value == "bar"
 
     def test_load_integration_data_invalid_target(self, mock_charm) -> None:
-        """Test that `_load_integration_data` raises an error when given an invalid target."""
+        """Test that ``_load_integration_data`` raises an error when given an invalid target."""
         with mock_charm(
             mock_charm.on.update_status(),
             state=testing.State(relations={make_integration()}),
@@ -241,6 +241,76 @@ class TestInterface:
 
         integration = state.get_relation(1)
         assert integration.local_app_data == {"name": '"foo"', "value": '"bar"'}
+
+    def test_save_merge_preserves_unmodified_fields(self, mock_charm, with_id) -> None:
+        """Test that ``merge=True`` only overwrites fields that differ from their defaults."""
+        with mock_charm(
+            mock_charm.on.update_status(),
+            state=testing.State(leader=True, relations={make_integration(id=1)}),
+        ) as manager:
+            manager.charm.interface.save(
+                ExampleData(name="foo", value="bar"),
+                target=manager.charm.app,
+            )
+            manager.charm.interface.save(
+                ExampleData(name="baz"),
+                target=manager.charm.app,
+                integration_id=1 if with_id else None,
+                merge=True,
+            )
+            state = manager.run()
+
+        integration = state.get_relation(1)
+        assert integration.local_app_data == {"name": '"baz"', "value": '"bar"'}
+
+    def test_save_merge_into_empty_databag(self, mock_charm) -> None:
+        """Test that merging into an empty databag preserves unset fields at their defaults."""
+        with mock_charm(
+            mock_charm.on.update_status(),
+            state=testing.State(leader=True, relations={make_integration(id=1)}),
+        ) as manager:
+            manager.charm.interface.save(
+                ExampleData(name="foo"),
+                target=manager.charm.app,
+                merge=True,
+            )
+            state = manager.run()
+
+        integration = state.get_relation(1)
+        assert integration.local_app_data == {"name": '"foo"', "value": '""'}
+
+    def test_save_merge_requires_dataclass(self, mock_charm) -> None:
+        """Test that ``TypeError`` is raised if ``data`` isn't a dataclass and ``merge=True``."""
+        with mock_charm(
+            mock_charm.on.update_status(),
+            state=testing.State(leader=True, relations={make_integration(id=1)}),
+        ) as manager:
+            with pytest.raises(TypeError):
+                manager.charm.interface.save(
+                    "not-a-dataclass",
+                    target=manager.charm.app,
+                    merge=True,
+                )
+            manager.run()
+
+    def test_save_not_merge_overwrites_all_fields(self, mock_charm) -> None:
+        """merge=False (default) overwrites all fields even those set to defaults."""
+        with mock_charm(
+            mock_charm.on.update_status(),
+            state=testing.State(leader=True, relations={make_integration(id=1)}),
+        ) as manager:
+            manager.charm.interface.save(
+                ExampleData(name="foo", value="bar"),
+                target=manager.charm.app,
+            )
+            manager.charm.interface.save(
+                ExampleData(name="baz"),
+                target=manager.charm.app,
+            )
+            state = manager.run()
+
+        integration = state.get_relation(1)
+        assert integration.local_app_data == {"name": '"baz"', "value": '""'}
 
     def test_is_integration_active(self, mock_charm, integration_exists) -> None:
         """Test the `_is_integration_active` static method."""


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This pull request adds databag merging functionality to the `_save_integration_data` method in the `Interface` base class.

A `merge: bool` parameter can be used now to direct the `_save_integration_data` method to either overwrite or merge integration data. If a dataclass with "advanced" objects is used, and `decoder` must also be passed to `_save_integration_data` so that the integration data can be correctly loaded. This behavior can be properly encapsulated by a downstream interface like `SlurmctldProvider` or `SlurmctldRequirer`.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/canonical/charmed-hpc-libs/issues/113

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a non-user facing change to our HPC charm development SDK.