### PR TITLE
fix(conditions): loosen type restriction of `refresh` to `ops.Object`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charmed-hpc-libs"
-version = "0.4.0"
+version = "0.5.0"
 requires-python = ">=3.12"
 description = "Collection of utilities to manage HPC related services."
 authors = [

--- a/src/charmed_hpc_libs/ops/conditions.py
+++ b/src/charmed_hpc_libs/ops/conditions.py
@@ -44,7 +44,7 @@ class ConditionEvaluation(NamedTuple):  # noqa D101
     message: str = ""
 
 
-type Condition[T: ops.CharmBase] = Callable[[T], ConditionEvaluation]
+type Condition[T: ops.Object] = Callable[[T], ConditionEvaluation]
 
 
 class StopCharm(Exception):  # noqa N818
@@ -65,7 +65,7 @@ class StopCharm(Exception):  # noqa N818
         return f"StopCharm({self.status!r}, set_app_status={self.set_app_status!r})"
 
 
-def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None) -> Callable:
+def refresh[T: ops.Object](hook: Callable[[T], ops.StatusBase] | None = None) -> Callable:
     """Refresh a charm's status after running an event handler.
 
     Args:
@@ -74,11 +74,11 @@ def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None)
 
     def decorator(func: Callable[..., None]) -> Callable:
         @wraps(func)
-        def wrapper(charm: T, *args: ops.EventBase, **kwargs: Any) -> None:
+        def wrapper(obj: T, *args: ops.EventBase, **kwargs: Any) -> None:
             event, *_ = args
 
             try:
-                func(charm, *args, **kwargs)
+                func(obj, *args, **kwargs)
             except StopCharm as e:
                 _logger.debug(
                     (
@@ -86,15 +86,15 @@ def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None)
                         "on unit '%s'. setting unit status to `%s`",
                     ),
                     event.__class__.__name__,
-                    charm.__class__.__name__,
+                    obj.__class__.__name__,
                     func.__name__,
-                    charm.unit.name,  # type: ignore
+                    obj.model.unit.name,
                     e.status,
                 )
-                charm.unit.status = e.status
+                obj.model.unit.status = e.status
                 if e.set_app_status:
                     try:
-                        charm.app.status = e.status  # type: ignore
+                        obj.model.app.status = e.status
                         _logger.debug(
                             "setting app status to `%s`",
                             e.status,
@@ -107,15 +107,15 @@ def refresh[T: ops.CharmBase](hook: Callable[[T], ops.StatusBase] | None = None)
                 _logger.debug(
                     "running status check function `%s` to determine new status for unit '%s'",
                     hook.__name__,
-                    charm.unit.name,  # type: ignore
+                    obj.model.unit.name,
                 )
-                status = hook(charm)
+                status = hook(obj)
                 _logger.debug(
                     "new status for unit '%s' determined to be `%s`",
-                    charm.unit.name,  # type: ignore
+                    obj.model.unit.name,
                     status,
                 )
-                charm.unit.status = status
+                obj.model.unit.status = status
 
         return wrapper
 
@@ -126,28 +126,28 @@ def leader(func: Callable[..., Any]) -> Callable[..., Any]:
     """Only run method if the unit is the application leader, otherwise skip."""
 
     @wraps(func)
-    def wrapper(charm: ops.CharmBase, *args: Any, **kwargs: Any) -> Any:
-        if not charm.unit.is_leader():
+    def wrapper(obj: ops.Object, *args: Any, **kwargs: Any) -> Any:
+        if not obj.model.unit.is_leader():
             _logger.debug(
                 (
                     "unit '%s' is not the leader of the '%s' application, ",
                     "skipping run of method `%s.%s`",
                 ),
-                charm.unit.name,
-                charm.app.name,
-                charm.__class__.__name__,
+                obj.model.unit.name,
+                obj.model.app.name,
+                obj.__class__.__name__,
                 func.__name__,
             )
             return None
 
         _logger.debug(
             "unit '%s' is the leader of the '%s' application, running method `%s.%s`",
-            charm.unit.name,
-            charm.app.name,
-            charm.__class__.__name__,
+            obj.model.unit.name,
+            obj.model.app.name,
+            obj.__class__.__name__,
             func.__name__,
         )
-        return func(charm, *args, **kwargs)
+        return func(obj, *args, **kwargs)
 
     return wrapper
 
@@ -159,8 +159,8 @@ def integration_exists(name: str) -> Condition:
         name: Name of integration to check existence of.
     """
 
-    def wrapper(charm: ops.CharmBase) -> ConditionEvaluation:
-        return ConditionEvaluation(bool(charm.model.relations.get(name)), "")
+    def wrapper(obj: ops.Object) -> ConditionEvaluation:
+        return ConditionEvaluation(bool(obj.model.relations.get(name)), "")
 
     return wrapper
 
@@ -172,8 +172,8 @@ def integration_not_exists(name: str) -> Condition:
         name: Name of integration to check existence of.
     """
 
-    def wrapper(charm: ops.CharmBase) -> ConditionEvaluation:
-        not_exists = not bool(charm.model.relations.get(name))
+    def wrapper(obj: ops.Object) -> ConditionEvaluation:
+        not_exists = not bool(obj.model.relations.get(name))
         return ConditionEvaluation(
             not_exists, f"Waiting for integrations: [`{name}`]" if not_exists else ""
         )
@@ -193,12 +193,12 @@ def _status_unless(*conditions: Condition, status: type[ops.StatusBase]) -> Call
 
     def decorator(func: Callable[..., Any]):
         @wraps(func)
-        def wrapper(charm: ops.CharmBase, *args: ops.EventBase, **kwargs: Any) -> Any:
+        def wrapper(obj: ops.Object, *args: ops.EventBase, **kwargs: Any) -> Any:
             event, *_ = args
-            _logger.debug("handling event `%s` on %s", event, charm.unit.name)
+            _logger.debug("handling event `%s` on %s", event, obj.model.unit.name)
 
             for condition in conditions:
-                ok, message = condition(charm)
+                ok, message = condition(obj)
                 if not ok:
                     _logger.debug(
                         (
@@ -207,14 +207,14 @@ def _status_unless(*conditions: Condition, status: type[ops.StatusBase]) -> Call
                         ),
                         condition.__name__,
                         event,
-                        charm.unit.name,
+                        obj.model.unit.name,
                         status.__name__,
                         message,
                     )
                     event.defer()
                     raise StopCharm(status(message))
 
-            return func(charm, *args, **kwargs)
+            return func(obj, *args, **kwargs)
 
         return wrapper
 

--- a/tests/unit/ops/test_conditions.py
+++ b/tests/unit/ops/test_conditions.py
@@ -30,12 +30,12 @@ from charmed_hpc_libs.ops import (
 )
 
 
-def service_is_active(_: ops.CharmBase) -> ConditionEvaluation:
+def service_is_active(_: ops.Object) -> ConditionEvaluation:
     return ConditionEvaluation(False, "Waiting for service to start")
 
 
-def unit_is_leader(charm: ops.CharmBase) -> ConditionEvaluation:
-    is_leader = charm.unit.is_leader()
+def unit_is_leader(obj: ops.Object) -> ConditionEvaluation:
+    is_leader = obj.model.unit.is_leader()
     return ConditionEvaluation(is_leader, "Unit is not leader" if not is_leader else "")
 
 
@@ -55,16 +55,32 @@ def post_handler_checks(charm: ops.CharmBase) -> ops.StatusBase:
     return ops.ActiveStatus()
 
 
-class MockCharm(ops.CharmBase):
-    """Mock charm for testing the conditions pattern."""
+class MockDatabaseObserver(ops.Object):
+    """Mock ``integrations`` observer."""
 
-    def __init__(self, framework: ops.Framework) -> None:
-        super().__init__(framework)
+    def __init__(self, charm: "MockCharm", integration_name: str) -> None:
+        super().__init__(charm, f"{type(self).__name__}")
 
-        framework.observe(self.on.install, self._on_install)
-        framework.observe(self.on.config_changed, self._on_config_changed)
-        framework.observe(self.on.update_status, self._on_update_status)
-        framework.observe(self.on["database"].relation_created, self._on_database_relation_created)
+        self.charm = charm
+        self.framework.observe(
+            self.charm.on[integration_name].relation_created, self._on_database_relation_created
+        )
+
+    @refresh(hook=None)
+    @wait_unless(service_is_active)
+    def _on_database_relation_created(self, _: ops.RelationCreatedEvent) -> None: ...
+
+
+class MockLifecycleObserver(ops.Object):
+    """Mock ``operations`` observer."""
+
+    def __init__(self, charm: "MockCharm") -> None:
+        super().__init__(charm, f"{type(self).__name__}")
+        self.charm = charm
+
+        self.framework.observe(self.charm.on.install, self._on_install)
+        self.framework.observe(self.charm.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.charm.on.update_status, self._on_update_status)
 
     @refresh(hook=None)
     @block_unless(unit_is_leader)
@@ -73,14 +89,20 @@ class MockCharm(ops.CharmBase):
     @leader
     @block_unless(unit_is_leader)  # Ensure that `leader` is called before `block_unless`.
     def _on_config_changed(self, _: ops.ConfigChangedEvent) -> None:
-        self.unit.status = ops.MaintenanceStatus("Leader is updating settings")
+        self.charm.unit.status = ops.MaintenanceStatus("Leader is updating settings")
 
     @refresh(hook=post_handler_checks)
     def _on_update_status(self, _: ops.UpdateStatusEvent) -> None: ...
 
-    @refresh(hook=None)
-    @wait_unless(service_is_active)
-    def _on_database_relation_created(self, _: ops.RelationCreatedEvent) -> None: ...
+
+class MockCharm(ops.CharmBase):
+    """Mock charm for testing the conditions pattern."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+
+        self.lifecycle_observer = MockLifecycleObserver(self)
+        self.database_observer = MockDatabaseObserver(self, "database")
 
 
 @pytest.fixture(scope="function")
@@ -137,13 +159,15 @@ def test_refresh(mock_charm) -> None:
     assert state.unit_status == ops.BlockedStatus("Waiting for integrations: [`metrics-server`]")
 
 
-class AppStatusCharm(ops.CharmBase):
-    """Mock charm for testing `StopCharm` app status propagation."""
+class MockAppStatusObserver(ops.Object):
+    """Mock observer for testing that observers can set app statuses."""
 
-    def __init__(self, framework: ops.Framework) -> None:
-        super().__init__(framework)
-        framework.observe(self.on.install, self._on_install)
-        framework.observe(self.on.start, self._on_start)
+    def __init__(self, charm: "MockAppStatusCharm") -> None:
+        super().__init__(charm, f"{type(self).__name__}")
+
+        self._charm = charm
+        self.framework.observe(self._charm.on.install, self._on_install)
+        self.framework.observe(self._charm.on.start, self._on_start)
 
     @refresh(hook=None)
     def _on_install(self, _: ops.InstallEvent) -> None:
@@ -154,9 +178,18 @@ class AppStatusCharm(ops.CharmBase):
         raise StopCharm(ops.BlockedStatus("blocked for unit only"))
 
 
+class MockAppStatusCharm(ops.CharmBase):
+    """Mock charm for testing `StopCharm` app status propagation."""
+
+    def __init__(self, framework: ops.Framework) -> None:
+        super().__init__(framework)
+
+        self.lifecycle_observer = MockAppStatusObserver(self)
+
+
 @pytest.fixture(scope="function")
-def app_status_charm() -> testing.Context[AppStatusCharm]:
-    return testing.Context(AppStatusCharm, meta={"name": "app-status-charm"})
+def app_status_charm() -> testing.Context[MockAppStatusCharm]:
+    return testing.Context(MockAppStatusCharm, meta={"name": "app-status-charm"})
 
 
 @pytest.mark.parametrize("is_leader", (True, False))

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "charmed-hpc-libs"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

The `refresh` decorator can currently not be used with Observers as defined in specification UHPC 010 because Observers inherit from `ops.Object`, not `ops.CharmBase`. `ops.Object` does not provide forwards to the `app` or `unit` attributes, so `refresh` will fail if it's wrapping an event handler defined on an Observer and not an object that inherits from `ops.CharmBase`. This change makes it so that `refresh` accesses the `app` and `unit` attributes through the `model` attribute. Both `ops.Object` and `ops.CharmBase` surface a `model` attribute since `ops.CharmBase` inherits from `ops.Object`.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Closes https://github.com/canonical/charmed-hpc-libs/issues/150

I also need this issue resolved so that I can unblock work on the `openssh` operator.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing change to our HPC charm development SDK.