### PR TITLE
test(cleanup): remove dead code from `interface` module unit tests

### DIFF
--- a/tests/unit/interfaces/test_interface.py
+++ b/tests/unit/interfaces/test_interface.py
@@ -61,16 +61,6 @@ class ExampleInterface(Interface):
         self._save_integration_data(data, target, **kwargs)
 
 
-class _Interface(Interface):
-    """Thin subclass exposing protected methods for testing."""
-
-    def load(self, cls, **kwargs):
-        return self._load_integration_data(cls, **kwargs)
-
-    def save(self, data, target, **kwargs) -> None:
-        self._save_integration_data(data, target, **kwargs)
-
-
 @dataclass
 class ExampleData:
     """Sample data manipulated by the mock charms."""


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR removes some dead code that I found in the unit tests for the `interface` module while working on https://github.com/canonical/slurm-charms/issues/224. The private `_Interface` class was originally created as a test helper, but I forgot to remove it after I decided the class was no longer necessary.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Discovered while working on https://github.com/canonical/slurm-charms/issues/224.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing change to our HPC charm development SDK.